### PR TITLE
Chroma-js missing as a bower dependency

### DIFF
--- a/src/bower.json
+++ b/src/bower.json
@@ -25,6 +25,7 @@
     "d3": "3.5.17",
     "semantic": "semantic-ui#^2.2.4",
     "golden-layout": "^1.5.6",
-    "bootstrap": "^3.3.7"
+    "bootstrap": "^3.3.7",
+    "chroma-js": "^1.3.3"
   }
 }


### PR DESCRIPTION
Fixes the inability to render the sankey plot