### PR TITLE
Ensure config file consistency

### DIFF
--- a/data/caliper-cali/callflow.config.json
+++ b/data/caliper-cali/callflow.config.json
@@ -6,12 +6,12 @@
     {
       "name": "caliper-ex",
       "path": "caliper-ex.json",
-      "format": "caliper_json"
+      "profile_format": "caliper_json"
     },
     {
       "name": "caliper-ex-2",
       "path": "caliper-ex.cali",
-      "format": "caliper"
+      "profile_format": "caliper"
     }
   ],
   "scheme": {

--- a/data/caliper-lulesh-json/callflow.config.json
+++ b/data/caliper-lulesh-json/callflow.config.json
@@ -6,7 +6,7 @@
     {
       "name": "lulesh",
       "path": "lulesh-sample-annotation-profile.json",
-      "format": "caliper_json"
+      "profile_format": "caliper_json"
     }
   ],
   "scheme": {

--- a/data/hpctoolkit-cpi-database/callflow.config.json
+++ b/data/hpctoolkit-cpi-database/callflow.config.json
@@ -6,7 +6,7 @@
     {
       "name": "calc-pi",
       "path": "",
-      "format": "hpctoolkit"
+      "profile_format": "hpctoolkit"
     }
   ],
   "scheme": {


### PR DESCRIPTION
This PR ensures if the fields of the config files (`callflow.config.json`) provided in the `data` folder are consistent.

- [x] Change "profile_format" to "format"

The final JSON fields look like the following
```
{
  "experiment": "String", (experiment name)
  "save_path": "String", (Path to store the .callflow folder)
  "read_parameter": "Boolean", (Create parameter view or not)
  "runs": Array(
    {
      "name": "String", (Run name)
      "path": "String", (Path to the dataset)
      "profile_format": "String" (Format of profile (hpctoolkit or caliper)
    }
  ),
  "scheme": {
    "filter_by": "String", (time or time (inc))
    "filter_perc": "Number",
    "group_by": "String",
    "module_map": {
      "String": Array(String) ("module_name": ["callsite_name1", "callsite_name2"]
  }
}

```