### PR TITLE
Restore the parameter projection view

### DIFF
--- a/app/src/components/callflowEnsemble.vue
+++ b/app/src/components/callflowEnsemble.vue
@@ -491,12 +491,11 @@
 					<span>
 						<CallsiteCorrespondence ref="CallsiteCorrespondence" />
 					</span>
-					<!-- <span> -->
-						<!-- <ParameterProjection
+					<span>
+						<ParameterProjection
 							ref="ParameterProjection"
-							@compare="updateCompareMode"
-						/> -->
-					<!-- </span> -->
+						/>
+					</span>
 				</splitpanes>
 			</splitpanes>
 		</v-layout>
@@ -566,7 +565,7 @@ import CallsiteCorrespondence from "./callsiteCorrespondence/callsiteCorresponde
 import EnsembleHistogram from "./ensembleHistogram/ensembleHistogram";
 import ModuleHierarchy from "./moduleHierarchy/moduleHierarchy";
 import EnsembleScatterplot from "./ensembleScatterplot/ensembleScatterplot";
-// import ParameterProjection from "./parameterProjection/parameterProjection";
+import ParameterProjection from "./parameterProjection/parameterProjection";
 
 import io from "socket.io-client";
 import * as utils from "./utils";
@@ -582,7 +581,7 @@ export default {
 		EnsembleScatterplot,
 		EnsembleHistogram,
 		ModuleHierarchy,
-		// ParameterProjection,
+		ParameterProjection,
 		CallsiteCorrespondence,
 	},
 
@@ -928,7 +927,7 @@ export default {
 				this.$refs.EnsembleHistogram,
 				this.$refs.EnsembleScatterplot,
 				this.$refs.CallsiteCorrespondence,
-				// this.$refs.ParameterProjection,
+				this.$refs.ParameterProjection,
 				this.$refs.ModuleHierarchy,
 			];
 		},

--- a/app/src/components/callsiteCorrespondence/callsiteCorrespondence.vue
+++ b/app/src/components/callsiteCorrespondence/callsiteCorrespondence.vue
@@ -319,7 +319,7 @@ export default {
 		init() {
 			if (this.firstRender) {
 				this.width = document.getElementById(this.id).clientWidth;
-				let heightRatio = this.$store.selectedMode == "Ensemble" ? 1.0 : 1.0;
+				let heightRatio = this.$store.selectedMode == "Ensemble" ? 0.65 : 1.0;
 				this.height = heightRatio * this.$store.viewHeight;
 				this.boxplotWidth = this.width - this.padding.left - this.padding.right;
 				document.getElementById(this.id).style.maxHeight = this.height + "px";


### PR DESCRIPTION
This PR brings back the projection view to the `/ensemble` endpoint in the client. 