### PR TITLE
Fix installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ callflow/unused/*
 app/node_modules*
 app/src/unused/*
 
+callflow/app
+callflow/data
+callflow/examples
+
 designs/*
 
 videos/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+include pyproject.toml
+
+# Include the README
+include *.md
+
+# Include the license file
+include LICENSE.txt
+
+# Include the data files
+recursive-include app/dist *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,9 @@ include pyproject.toml
 include *.md
 
 # Include the license file
-include LICENSE.txt
+include LICENSE
 
 # Include the data files
+recursive-include data *
+recursive-include examples *
 recursive-include app/dist *

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CallFlow is structured as three components:
 The `callflow` (python package) requires [python](https://realpython.com/installing-python/) (>= 3.6) and [pip](https://pip.pypa.io/en/stable/news/) (>= 20.1.1). Other dependencies are checked/installed during the installation of `callflow` using `setup.py`.
 
 ```
-python3 setup.py install
+pip install callflow
 ```
 
 ## Sample Data
@@ -34,15 +34,10 @@ The processing of profiles generates a `.callflow` directory in the ${save_path}
 python3 callflow/server/callflow_server.py --data-dir {PATH_TO_DATA_DIRECTORY}
 ```
 
-Finally, the web application server can be run using
-```
-callflow_app
-```
 
-By default, the application would run on port, 8000. If the port needs to be changed, please set the environment variables using,
+By default, the application would run on port, 5000. If the port needs to be changed, please set the environment variables using,
 
 ```
-export CALLFLOW_SERVER_PORT=<port_number>
 export CALLFLOW_APP_PORT=<port_number>
 ```
 
@@ -61,11 +56,16 @@ npm install
 To start the `app`,
 
 ```
-npm run dev
+npm run serve
+```
+
+
+To build the `app`,
+```
+npm run build
 ```
 
 The basic architecture diagram can be found [here](/docs/figures/CallFlow-basic-architecture.png).
-
 ## CallFlow Citations
 
 Any published work that utilizes this software should include the following references:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CallFlow is structured as three components:
 The `callflow` (python package) requires [python](https://realpython.com/installing-python/) (>= 3.6) and [pip](https://pip.pypa.io/en/stable/news/) (>= 20.1.1). Other dependencies are checked/installed during the installation of `callflow` using `setup.py`.
 
 ```
-pip install callflow
+python3 setup.py install --prefix PATH/TO/INSTALL
 ```
 
 ## Sample Data
@@ -31,7 +31,7 @@ The processing of profiles generates a `.callflow` directory in the ${save_path}
 ### Running the server
 
 ```
-python3 callflow/server/callflow_server.py --data-dir {PATH_TO_DATA_DIRECTORY}
+/PATH/TO/INSTALL/callflow_server --data-dir {PATH_TO_DATA_DIRECTORY}
 ```
 
 

--- a/callflow/server/callflow_server.py
+++ b/callflow/server/callflow_server.py
@@ -10,7 +10,7 @@ import os
 import callflow
 from callflow.operations import ArgParser
 from callflow.server.api_provider import APIProvider
-import manager
+import callflow.server.manager as manager
 
 # Globals
 LOGGER = callflow.get_logger(__name__)

--- a/callflow/server/callflow_server.py
+++ b/callflow/server/callflow_server.py
@@ -14,8 +14,8 @@ import manager
 
 # Globals
 LOGGER = callflow.get_logger(__name__)
-CALLFLOW_SERVER_HOST = "127.0.0.1"
-CALLFLOW_SERVER_PORT = int(os.getenv("CALLFLOW_SERVER_PORT", 5000))
+CALLFLOW_APP_HOST = "127.0.0.1"
+CALLFLOW_APP_PORT = int(os.getenv("CALLFLOW_APP_PORT", 5000))
 
 
 class CallFlowServer:
@@ -58,11 +58,11 @@ class CallFlowServer:
         # Socket request handlers
         if len(self.args.config["parameter_props"]["runs"]) > 1:
             ensemble = True
-        # SocketProvider(host=CALLFLOW_SERVER_HOST, port=CALLFLOW_SERVER_PORT, ensemble=ensemble)
+
         APIProvider(
             callflow=self.callflow,
-            host=CALLFLOW_SERVER_HOST,
-            port=CALLFLOW_SERVER_PORT,
+            host=CALLFLOW_APP_HOST,
+            port=CALLFLOW_APP_PORT,
             ensemble=ensemble,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+  
+[build-system]
+# These are the assumed default build requirements from pip:
+# https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ networkx==2.2
 scipy==1.3.1
 numpy==1.17.2
 pandas==0.23.0
-Flask_SocketIO==4.2.1
 ipython==7.18.1
 scikit_learn==0.23.2

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,19 @@
 
 import os
 from setuptools import setup, find_packages
+import pathlib
+
+here = pathlib.Path(__file__).parent.resolve()
+
+# Get the long description from the README file
+long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 # ------------------------------------------------------------------------------
 # get the version safely!
 from codecs import open
 
 version = {}
-vfile = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "callflow", "version.py"
-)
+vfile = os.path.join(here, "callflow", "version.py")
 with open(vfile) as fp:
     exec(fp.read(), version)
 version = version["__version__"]
@@ -82,9 +86,9 @@ def list_files_update(directory, whitelist_files=[], whitelist_folders=[]):
     return paths
 
 
-data_files = list_files("data", whitelist_folders=_GITHUB_DATA_FOLDERS)
-example_files = list_files("examples", whitelist_files=_GITHUB_EXAMPLE_FILES)
-app_dist_files = list_files("app/dist", whitelist_folders=_APP_DIST_FOLDERS)
+data_files = list_files_update("data", whitelist_folders=_GITHUB_DATA_FOLDERS)
+example_files = list_files_update("examples", whitelist_files=_GITHUB_EXAMPLE_FILES)
+app_dist_files = list_files_update("app/dist", whitelist_folders=_APP_DIST_FOLDERS)
 
 deps = [
     "ipython",
@@ -105,7 +109,7 @@ setup(
     name="CallFlow",
     version=version,
     license="MIT",
-    description="",
+    description=long_description,
     url="https://github.com/LLNL/CallFlow",
     author="Suraj Kesavan",
     author_email="spkesavan@ucdavis.edu",
@@ -117,7 +121,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     # data_files=data_files + example_files + app_dist_files,
-    package_data= {
+    package_data={
         "data": data_files, 
         "examples": example_files,
         "app": app_dist_files,

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,20 @@ data_files = list_files_update("data", whitelist_folders=_GITHUB_DATA_FOLDERS)
 example_files = list_files_update("examples", whitelist_files=_GITHUB_EXAMPLE_FILES)
 app_dist_files = list_files_update("app/dist", whitelist_folders=_APP_DIST_FOLDERS)
 
+# ------------------------------------------------------------------------------
+# these folders live outside the callflow "package" in the src distribution
+# but we want to install them within the callflow installed package
+# i.e., in .../site-packages/callflow/app
+# so, let's create a symlink inside the callflow folder
+# so setuptools can place them relative to the installed package
+if True:
+    os.chdir('./callflow')
+    for _ in ['data', 'app', 'examples']:
+        if not os.path.islink(_):
+            os.symlink(os.path.join('..', _), _)
+    os.chdir('..')
+
+# ------------------------------------------------------------------------------
 deps = [
     "ipython",
     "colorlog",
@@ -103,6 +117,7 @@ deps = [
     "networkx",
     "matplotlib",
 ]
+
 # ------------------------------------------------------------------------------
 # now set up
 setup(
@@ -120,12 +135,7 @@ setup(
     keywords="",
     packages=find_packages(),
     include_package_data=True,
-    # data_files=data_files + example_files + app_dist_files,
-    package_data={
-        "data": data_files, 
-        "examples": example_files,
-        "app": app_dist_files,
-    },
+    package_data={'callflow': data_files + example_files + app_dist_files},
     entry_points={
         "console_scripts": [
             "callflow_server = callflow.server.callflow_server:main",
@@ -133,5 +143,4 @@ setup(
     },
     install_requires=deps,
 )
-
 # ------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,37 @@ _GITHUB_EXAMPLE_FILES = [
     "CallFlow-python-interface-demo.ipynb",
 ]
 
+_APP_DIST_FOLDERS = [
+    "js",
+    "css",
+    "fonts",
+    "index.html"
+]
+
+# # gather the data to be copied
+# def list_files(directory, whitelist_files=[], whitelist_folders=[]):
+#     paths = []
+#     if len(whitelist_folders) > 0:
+#         for item in os.listdir(directory):
+#             if item in whitelist_folders:
+#                 for (path, directories, filenames) in os.walk(
+#                     os.path.join(directory, item)
+#                 ):
+#                     if ".callflow" not in path.split("/"):
+#                         paths.append((path, [os.path.join(path, f) for f in filenames]))
+
+#     if len(whitelist_files) > 0:
+#         for (path, directories, filenames) in os.walk(directory):
+#             paths.append(
+#                 (
+#                     path,
+#                     [os.path.join(path, f) for f in filenames if f in whitelist_files],
+#                 )
+#             )
+#     return paths
 
 # gather the data to be copied
-def list_files(directory, whitelist_files=[], whitelist_folders=[]):
+def list_files_update(directory, whitelist_files=[], whitelist_folders=[]):
     paths = []
     if len(whitelist_folders) > 0:
         for item in os.listdir(directory):
@@ -46,25 +74,19 @@ def list_files(directory, whitelist_files=[], whitelist_folders=[]):
                     os.path.join(directory, item)
                 ):
                     if ".callflow" not in path.split("/"):
-                        paths.append((path, [os.path.join(path, f) for f in filenames]))
+                        paths = [os.path.join(path, f) for f in filenames]
 
     if len(whitelist_files) > 0:
         for (path, directories, filenames) in os.walk(directory):
-            paths.append(
-                (
-                    path,
-                    [os.path.join(path, f) for f in filenames if f in whitelist_files],
-                )
-            )
+            paths = [os.path.join(path, f) for f in filenames if f in whitelist_files]
     return paths
 
 
 data_files = list_files("data", whitelist_folders=_GITHUB_DATA_FOLDERS)
 example_files = list_files("examples", whitelist_files=_GITHUB_EXAMPLE_FILES)
-
+app_dist_files = list_files("app/dist", whitelist_folders=_APP_DIST_FOLDERS)
 
 deps = [
-    "flask_socketio",
     "ipython",
     "colorlog",
     "jsonschema",
@@ -93,11 +115,16 @@ setup(
     ],
     keywords="",
     packages=find_packages(),
-    data_files=data_files + example_files,
+    include_package_data=True,
+    # data_files=data_files + example_files + app_dist_files,
+    package_data= {
+        "data": data_files, 
+        "examples": example_files,
+        "app": app_dist_files,
+    },
     entry_points={
         "console_scripts": [
             "callflow_server = callflow.server.callflow_server:main",
-            "callflow_app = app.app:main",
         ]
     },
     install_requires=deps,

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
 import os
 from setuptools import setup, find_packages
 import pathlib
+
 # get the version safely!
 from codecs import open
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import pathlib
 here = pathlib.Path(__file__).parent.resolve()
 
 # Get the long description from the README file
-long_description = (here / 'README.md').read_text(encoding='utf-8')
+long_description = (here / "README.md").read_text(encoding="utf-8")
 
 # ------------------------------------------------------------------------------
 # get the version safely!
@@ -30,7 +30,7 @@ version = version["__version__"]
 _GITHUB_DATA_FOLDERS = [
     "caliper-cali",
     "caliper-lulesh-json",
-    "hpctoolkit-cpi-database",
+    "hpctoolkit-cpi-databases",
 ]
 
 # Only allow jupyter notebooks in https://github.com/LLNL/CallFlow/tree/develop/example to be added.
@@ -43,30 +43,9 @@ _APP_DIST_FOLDERS = [
     "js",
     "css",
     "fonts",
-    "index.html"
 ]
 
-# # gather the data to be copied
-# def list_files(directory, whitelist_files=[], whitelist_folders=[]):
-#     paths = []
-#     if len(whitelist_folders) > 0:
-#         for item in os.listdir(directory):
-#             if item in whitelist_folders:
-#                 for (path, directories, filenames) in os.walk(
-#                     os.path.join(directory, item)
-#                 ):
-#                     if ".callflow" not in path.split("/"):
-#                         paths.append((path, [os.path.join(path, f) for f in filenames]))
-
-#     if len(whitelist_files) > 0:
-#         for (path, directories, filenames) in os.walk(directory):
-#             paths.append(
-#                 (
-#                     path,
-#                     [os.path.join(path, f) for f in filenames if f in whitelist_files],
-#                 )
-#             )
-#     return paths
+_APP_DIST_INDEX_HTML = ["index.html"]
 
 # gather the data to be copied
 def list_files_update(directory, whitelist_files=[], whitelist_folders=[]):
@@ -78,17 +57,21 @@ def list_files_update(directory, whitelist_files=[], whitelist_folders=[]):
                     os.path.join(directory, item)
                 ):
                     if ".callflow" not in path.split("/"):
-                        paths = [os.path.join(path, f) for f in filenames]
+                        paths += [os.path.join(path, f) for f in filenames]
 
     if len(whitelist_files) > 0:
         for (path, directories, filenames) in os.walk(directory):
-            paths = [os.path.join(path, f) for f in filenames if f in whitelist_files]
+            paths += [os.path.join(path, f) for f in filenames if f in whitelist_files]
+
     return paths
 
 
 data_files = list_files_update("data", whitelist_folders=_GITHUB_DATA_FOLDERS)
 example_files = list_files_update("examples", whitelist_files=_GITHUB_EXAMPLE_FILES)
-app_dist_files = list_files_update("app/dist", whitelist_folders=_APP_DIST_FOLDERS)
+app_dist_folders = list_files_update("app/dist", whitelist_folders=_APP_DIST_FOLDERS)
+app_dist_index_html = list_files_update(
+    "app/dist", whitelist_files=_APP_DIST_INDEX_HTML
+)
 
 # ------------------------------------------------------------------------------
 # these folders live outside the callflow "package" in the src distribution
@@ -97,11 +80,11 @@ app_dist_files = list_files_update("app/dist", whitelist_folders=_APP_DIST_FOLDE
 # so, let's create a symlink inside the callflow folder
 # so setuptools can place them relative to the installed package
 if True:
-    os.chdir('./callflow')
-    for _ in ['data', 'app', 'examples']:
+    os.chdir("./callflow")
+    for _ in ["data", "app", "examples"]:
         if not os.path.islink(_):
-            os.symlink(os.path.join('..', _), _)
-    os.chdir('..')
+            os.symlink(os.path.join("..", _), _)
+    os.chdir("..")
 
 # ------------------------------------------------------------------------------
 deps = [
@@ -135,11 +118,11 @@ setup(
     keywords="",
     packages=find_packages(),
     include_package_data=True,
-    package_data={'callflow': data_files + example_files + app_dist_files},
+    package_data={
+        "callflow": data_files + example_files + app_dist_folders + app_dist_index_html
+    },
     entry_points={
-        "console_scripts": [
-            "callflow_server = callflow.server.callflow_server:main",
-        ]
+        "console_scripts": ["callflow_server = callflow.server.callflow_server:main",]
     },
     install_requires=deps,
 )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@
 import os
 from setuptools import setup, find_packages
 import pathlib
+# get the version safely!
+from codecs import open
 
 here = pathlib.Path(__file__).parent.resolve()
 
@@ -13,9 +15,6 @@ here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / "README.md").read_text(encoding="utf-8")
 
 # ------------------------------------------------------------------------------
-# get the version safely!
-from codecs import open
-
 version = {}
 vfile = os.path.join(here, "callflow", "version.py")
 with open(vfile) as fp:
@@ -47,8 +46,15 @@ _APP_DIST_FOLDERS = [
 
 _APP_DIST_INDEX_HTML = ["index.html"]
 
-# gather the data to be copied
+
 def list_files_update(directory, whitelist_files=[], whitelist_folders=[]):
+    """
+    Returns the paths of all children files after checking it with the
+    whitelisted folders or files.
+    directory: Path to iterate
+    whitelist_files: Array(files to only consider)
+    whitelist_folders: Array(folders to only consider)
+    """
     paths = []
     if len(whitelist_folders) > 0:
         for item in os.listdir(directory):
@@ -79,12 +85,11 @@ app_dist_index_html = list_files_update(
 # i.e., in .../site-packages/callflow/app
 # so, let's create a symlink inside the callflow folder
 # so setuptools can place them relative to the installed package
-if True:
-    os.chdir("./callflow")
-    for _ in ["data", "app", "examples"]:
-        if not os.path.islink(_):
-            os.symlink(os.path.join("..", _), _)
-    os.chdir("..")
+os.chdir("./callflow")
+for _ in ["data", "app", "examples"]:
+    if not os.path.islink(_):
+        os.symlink(os.path.join("..", _), _)
+os.chdir("..")
 
 # ------------------------------------------------------------------------------
 deps = [
@@ -122,7 +127,9 @@ setup(
         "callflow": data_files + example_files + app_dist_folders + app_dist_index_html
     },
     entry_points={
-        "console_scripts": ["callflow_server = callflow.server.callflow_server:main",]
+        "console_scripts": [
+            "callflow_server = callflow.server.callflow_server:main",
+        ]
     },
     install_requires=deps,
 )


### PR DESCRIPTION
Puts `app`, `data`, and `examples` folders inside `site-packages/callflow` folder.

This really is a hack. I create a symlink from `CallFlow/app` --> `CallFlow/callflow/app` and then force setup to use that as the package data. May be there is a better way, but this one works.

I tested with the following:
`python setup.py sdist`
`python setup.py bdist`
`python setup.py bdist_wheel`
`python setup.py install`
`pip install .`


Fun thing I learned today: `sdist` uses `MANIFEST` file, but `bdist` etc. use `package_dir` argument