### PR TITLE
CAL-27: Fix single data processing

### DIFF
--- a/callflow/modules/auxiliary.py
+++ b/callflow/modules/auxiliary.py
@@ -39,7 +39,10 @@ class EnsembleAuxiliary:
         self.timer = Timer()
         self.props = props
         self.datasets = datasets
-        self.df = self.select_rows(self.gf.df, self.datasets)
+        if len(self.datasets) > 1:
+            self.df = self.select_rows(self.gf.df, self.datasets)
+        else:
+            self.df = self.gf.df
         self.process = process
         self.hist_props = ["rank", "name", "dataset", "all_ranks"]
         self.filter = True

--- a/callflow/operations/argparser.py
+++ b/callflow/operations/argparser.py
@@ -294,16 +294,30 @@ class ArgParser:
             f.path for f in os.scandir(data_path) if f.is_dir()
         ]
 
-        for idx, subfolder_path in enumerate(list_subfolders_with_paths):
-            name = subfolder_path.split("/")[-1]
-            if name != ".callflow":
-                run = {
-                    "name": name,
-                    "path": name,
-                    "profile_format": "hpctoolkit",
-                }
+        list_files_inside_data_path = [
+            f.path.split("/")[-1] for f in os.scandir(data_path)
+        ]
 
-                runs.append(run)
+        # Check if experiment.xml and metric-db's is in the directory, if so, it
+        # is the data directory.
+        if "experiment.xml" in list_files_inside_data_path:
+            run = {
+                "name": data_path.split("/")[-1],
+                "path": "/".join(data_path.split("/")[:-1]),
+                "profile_format": "hpctoolkit",
+            }
+            runs.append(run)
+
+        else:
+            for idx, subfolder_path in enumerate(list_subfolders_with_paths):
+                name = subfolder_path.split("/")[-1]
+                if name != ".callflow":
+                    run = {
+                        "name": name,
+                        "path": "/".join(subfolder_path.split("/")[:-1]),
+                        "profile_format": "hpctoolkit",
+                    }
+                    runs.append(run)
 
         return runs
 


### PR DESCRIPTION
- [x] Fix the single data processing.
- [x] Update the processing pipeline with correct auxiliary mapping.
- [x] Detect the data directory for hpctoolkit data (using experiment.xml and .metric-db).  

Note: Merge after [CAL-28: Data updates](https://github.com/LLNL/CallFlow/pull/50) is merged.