### PR TITLE
CAL-89: Add info icon to the component chips

### DIFF
--- a/app/src/components/SuperGraph.vue
+++ b/app/src/components/SuperGraph.vue
@@ -135,9 +135,9 @@ import "splitpanes/dist/splitpanes.css";
 import EventHandler from "lib/routing/EventHandler";
 
 // Super graph dashboard imports
-import SingleScatterplot from "./singleScatterplot/singleScatterplot";
-import SingleHistogram from "./singleHistogram/singleHistogram";
-import CallsiteInformation from "./callsiteInformation/callsiteInformation";
+import SingleScatterplot from "./singleScatterplot/";
+import SingleHistogram from "./singleHistogram/";
+import CallsiteInformation from "./callsiteInformation/";
 import Sankey from "./sankey/";
 import Toolbar from "./general/toolbar";
 

--- a/app/src/components/SuperGraphEnsemble.vue
+++ b/app/src/components/SuperGraphEnsemble.vue
@@ -612,10 +612,6 @@ export default {
 			this.clear();
 			this.init();
 		},
-
-		closeSettings() {
-			this.isSettingsOpen = !this.isSettingsOpen;
-		},
 	},
 };
 </script>

--- a/app/src/components/SuperGraphEnsemble.vue
+++ b/app/src/components/SuperGraphEnsemble.vue
@@ -242,11 +242,11 @@ import EventHandler from "lib/routing/EventHandler";
 import APIService from "lib/routing/APIService";
 
 // Ensemble super graph dashboard imports
-import CallsiteCorrespondence from "./callsiteCorrespondence/callsiteCorrespondence";
-import EnsembleHistogram from "./ensembleHistogram/ensembleHistogram";
-import ModuleHierarchy from "./moduleHierarchy/moduleHierarchy";
-import EnsembleScatterplot from "./ensembleScatterplot/ensembleScatterplot";
-import ParameterProjection from "./parameterProjection/parameterProjection";
+import CallsiteCorrespondence from "./callsiteCorrespondence";
+import EnsembleHistogram from "./ensembleHistogram/";
+import ModuleHierarchy from "./moduleHierarchy/";
+import EnsembleScatterplot from "./ensembleScatterplot/";
+import ParameterProjection from "./parameterProjection/";
 import Sankey from "./sankey/";
 import Toolbar from "./general/toolbar";
 

--- a/app/src/components/callsiteCorrespondence/callsiteCorrespondence.vue
+++ b/app/src/components/callsiteCorrespondence/callsiteCorrespondence.vue
@@ -85,7 +85,6 @@
                   text-xs-center
                   :class="selectClassName[callsite.name]"
                   @click="changeSelectedClassName"
-                  style=""
                 >
                   {{ formatNumberOfHops(callsite.component_level) }}
                 </v-flex>

--- a/app/src/components/callsiteCorrespondence/index.vue
+++ b/app/src/components/callsiteCorrespondence/index.vue
@@ -6,14 +6,7 @@
  */
 <template>
   <v-layout row wrap :id="id">
-    <v-chip class="chip" chips color="teal" label outlined clearable>
-      {{ message }}
-    </v-chip>
-    <v-spacer></v-spacer>
-    <span class="component-info">
-      <p></p>
-    </span>
-
+	<InfoChip ref="InfoChip" :title="title" :summary="summary" />
     <v-layout row wrap v-if="isCallsiteSelected == true">
       <v-btn
         class="ma-1 reveal-button"
@@ -225,6 +218,8 @@ import * as d3 from "d3";
 import * as utils from "lib/utils";
 import EventHandler from "lib/routing/EventHandler";
 
+import InfoChip from "../general/infoChip";
+
 // Local component imports
 import BoxPlot from "./boxplot";
 
@@ -232,12 +227,14 @@ export default {
 	name: "CallsiteCorrespondence",
 	components: {
 		BoxPlot,
+		InfoChip
 	},
 	data: () => ({
 		selected: {},
 		id: "auxiliary-function-overview",
 		people: [],
-		message: "Call Site Correspondence",
+		title: "Call Site Correspondence",
+		summary: "",
 		callsites: [],
 		dataReady: false,
 		numberOfIntersectionCallsites: 0,

--- a/app/src/components/callsiteInformation/index.vue
+++ b/app/src/components/callsiteInformation/index.vue
@@ -7,10 +7,7 @@
 
 <template>
   <v-layout row wrap :id="id">
-    <v-chip class="chip" chips color="teal" label outlined clearable>
-      {{ message }}
-    </v-chip>
-    <v-spacer></v-spacer>
+	<InfoChip ref="InfoChip" :title="title" :summary="summary" />
     <v-layout row wrap v-if="isCallsiteSelected == true">
       <v-btn
         class="ma-1 reveal-button"
@@ -134,6 +131,8 @@ import * as d3 from "d3";
 import * as utils from "lib/utils";
 import EventHandler from "lib/routing/EventHandler";
 
+import InfoChip from "../general/infoChip";
+
 // Local component imports
 import BoxPlot from "./boxplot";
 
@@ -141,10 +140,13 @@ export default {
 	name: "CallsiteInformation",
 	components: {
 		BoxPlot,
+		InfoChip
 	},
 	data: () => ({
 		id: "callsite-information-overview",
-		message: "Call site Information",
+		title: "Call site Information",
+		summary: "",
+		info: "",
 		callsites: [],
 		numberOfcallsites: 0,
 		firstRender: true,

--- a/app/src/components/ensembleHistogram/index.vue
+++ b/app/src/components/ensembleHistogram/index.vue
@@ -7,15 +7,7 @@
 
  <template>
   <div :id="id">
-    <v-layout class="chip-container">
-      <v-chip class="chip" chips color="teal" label outlined clearable>
-        {{ message }}
-      </v-chip>
-      <v-spacer></v-spacer>
-      <span class="component-info">
-        Number of {{ selectedPropLabel }} = {{ selectedPropSum }}
-      </span>
-    </v-layout>
+	<InfoChip ref="InfoChip" :title="title" :summary="summary" :info="info"/>
     <svg :id="svgID"></svg>
     <ToolTip ref="ToolTip" />
   </div>
@@ -30,6 +22,8 @@ import "d3-selection-multi";
 import * as utils from "lib/utils";
 import EventHandler from "lib/routing/EventHandler";
 
+import InfoChip from "../general/infoChip";
+
 // Local component imports
 import ToolTip from "./tooltip";
 
@@ -37,6 +31,7 @@ export default {
 	name: "EnsembleHistogram",
 	components: {
 		ToolTip,
+		InfoChip
 	},
 	props: [],
 	data: () => ({
@@ -57,7 +52,9 @@ export default {
 		freq: [],
 		selectedColorBy: "Inclusive",
 		MPIcount: 0,
-		message: "Runtime Distribution",
+		title: "Runtime Distribution",
+		summary: "",
+		info: "",
 		paddingFactor: 3.5,
 		thisNode: "",
 		selectedPropLabel: "",
@@ -188,9 +185,13 @@ export default {
 			} else if (this.$store.selectedProp == "dataset") {
 				this.selectedPropLabel = "Runs";
 			}
+
 			this.selectedPropSum = this.freq.reduce((acc, val) => {
 				return acc + val;
 			});
+
+			this.info = "Number of " + this.selectedPropLabel + "= "+ this.selectedPropSum;
+			
 		},
 
 		clear() {

--- a/app/src/components/ensembleScatterplot/index.vue
+++ b/app/src/components/ensembleScatterplot/index.vue
@@ -6,16 +6,10 @@
  */
 <template>
 	<v-layout row wrap :id="id">
-    <v-layout class="chip-container">
-        <v-chip class="chip" chips color="teal" label outlined clearable> {{ message }} </v-chip>
-        <v-spacer> </v-spacer>
-    </v-layout>
-    <span class="component-info">
-        <!-- Max. QCD= {{maxVarianceCallsite}} -->
-    </span>
-    <svg :id="svgID"></svg>
-    <ToolTip ref="ToolTip" />
-</v-layout>
+		<InfoChip ref="InfoChip" :title="title" :summary="summary" />
+		<svg :id="svgID"></svg>
+		<ToolTip ref="ToolTip" />
+	</v-layout>
 </template>
 
 
@@ -25,6 +19,9 @@ import * as d3 from "d3";
 
 // Local library
 import * as utils from "lib/utils";
+
+import InfoChip from "../general/infoChip";
+
 import EventHandler from "lib/routing/EventHandler";
 
 // Local components
@@ -34,6 +31,7 @@ export default {
 	name: "EnsembleScatterplot",
 	components: {
 		ToolTip,
+		InfoChip
 	},
 	data: () => ({
 		padding: {
@@ -52,7 +50,9 @@ export default {
 		nameData: [],
 		id: "ensemble-scatterplot-view",
 		svgID: "ensemble-scatterplot-view-svg",
-		message: "Metric Correlation",
+		title: "Metric Correlation",
+		info: "",
+		message: "",
 		boxOffset: 20,
 		settings: [{ title: "Show Difference plot" }, { title: "aaa" }],
 		moduleUnDesirability: 1,

--- a/app/src/components/general/infoChip.vue
+++ b/app/src/components/general/infoChip.vue
@@ -1,20 +1,45 @@
 <template>
+  <v-flex row wrap>
     <v-chip class="chip" chips color="teal" label outlined clearable>
+      <span class="chip-title">
         {{ title }}
-        <v-tooltip bottom>
-            <template v-slot:activator="{ on }">
-                <v-icon v-on="on" color="white" dark >info</v-icon>
-            </template>
-            <span>
-                {{summary}}
-            </span>
-        </v-tooltip>
+      </span>
+      <v-tooltip bottom>
+        <template v-slot:activator="{on}">
+          <v-icon v-on="on" color="white" dark>info</v-icon>
+        </template>
+        <span>
+          {{ summary }}
+        </span>
+      </v-tooltip>
     </v-chip>
+    <v-spacer></v-spacer>
+    <span class="chip-info">
+      {{ info }}
+    </span>
+  </v-flex>
 </template>
 
 <script>
 export default {
 	name: "InfoChip",
-	props: ["title", "summary"]
+	props: ["title", "summary", "info"],
 };
 </script>
+
+<style scoped>
+.chip {
+  padding: 1px;
+  font-size: 14px;
+}
+
+.chip-title {
+  padding: 1px;
+  margin: 0px;
+}
+
+.chip-info {
+  color: #009688;
+  padding-left: 0px;
+}
+</style>

--- a/app/src/components/general/infoChip.vue
+++ b/app/src/components/general/infoChip.vue
@@ -1,0 +1,28 @@
+<template>
+    <v-chip class="chip" chips color="teal" label outlined clearable>
+        {{ title }}
+        <v-icon>info</v-icon>
+        <v-card class="mx-auto" tile outlined>
+            <v-tooltip bottom>
+                <template >
+                    <v-flex
+                    id="summary"
+                    text-xs-center
+                    >
+                    {{ summary }}
+                    </v-flex>
+                </template>
+                <!-- <span> -->
+                    {{summary}}
+                <!-- </span> -->
+            </v-tooltip>
+        </v-card>
+    </v-chip>
+</template>
+
+<script>
+export default {
+	name: "InfoChip",
+	props: ["title", "summary"]
+};
+</script>

--- a/app/src/components/general/infoChip.vue
+++ b/app/src/components/general/infoChip.vue
@@ -1,22 +1,14 @@
 <template>
     <v-chip class="chip" chips color="teal" label outlined clearable>
         {{ title }}
-        <v-icon>info</v-icon>
-        <v-card class="mx-auto" tile outlined>
-            <v-tooltip bottom>
-                <template >
-                    <v-flex
-                    id="summary"
-                    text-xs-center
-                    >
-                    {{ summary }}
-                    </v-flex>
-                </template>
-                <!-- <span> -->
-                    {{summary}}
-                <!-- </span> -->
-            </v-tooltip>
-        </v-card>
+        <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+                <v-icon v-on="on" color="white" dark >info</v-icon>
+            </template>
+            <span>
+                {{summary}}
+            </span>
+        </v-tooltip>
     </v-chip>
 </template>
 

--- a/app/src/components/moduleHierarchy/index.vue
+++ b/app/src/components/moduleHierarchy/index.vue
@@ -7,11 +7,7 @@
 
 <template>
   <v-layout row wrap :id="id">
-    <v-layout class="chip-container">
-      <v-chip class="chip" chips color="teal" label outlined clearable>
-        {{ message }}
-      </v-chip>
-    </v-layout>
+	<InfoChip ref="InfoChip" :title="title" :summary="summary" :info="info"/>
     <span class="component-info">
       Module = {{ formatModule(selectedModule) }}
     </span>
@@ -73,12 +69,14 @@ export default {
 		path_hierarchy: [],
 		id: "",
 		padding: 0,
-		message: "Supernode Hierarchy",
 		offset: 4,
 		stroke_width: 4,
 		metric: "",
 		selectedModule: "",
 		svgID: "module-hierarchy-svg",
+		title: "Super node Hierarchy",
+		summary: "",
+		info: "",
 	}),
 
 	watch: {

--- a/app/src/components/nodeLink/index.vue
+++ b/app/src/components/nodeLink/index.vue
@@ -6,10 +6,15 @@
  */
 
 <template>
-  <svg :id="id">
-    <g id="container"></g>
-    <ColorMap ref="ColorMap" />
-  </svg>
+  <div>
+    <v-layout class="chip-container">
+      <InfoChip ref="InfoChip" :title="title" :summary="summary" />
+    </v-layout>
+    <svg :id="id">
+      <g id="container"></g>
+      <ColorMap ref="ColorMap" />
+    </svg>
+  </div>
 </template>
 
 <script>
@@ -20,12 +25,14 @@ import APIService from "lib/routing/APIService";
 import EventHandler from "lib/routing/EventHandler";
 
 import ColorMap from "../general/colormap";
+import InfoChip from "../general/infoChip";
 import * as utils from "lib/utils";
 
 export default {
 	name: "NodeLink",
 	components: {
 		ColorMap,
+		InfoChip
 	},
 
 	data: () => ({
@@ -41,6 +48,8 @@ export default {
 		zoom: null,
 		HAS_DATA_COLUMNS: ["module"], // Array of keys in incoming data to check for.
 		has_data_map: {}, // stores if the required data points are present in the incoming data.
+		title: "CCT view",
+		summary: "This view provides the CCT "
 	}),
 
 	mounted() {
@@ -50,7 +59,7 @@ export default {
 			self.init();
 		});
 	},
-	
+		
 	methods: {
 		/**
 		 * Send the request to /init endpoint

--- a/app/src/components/parameterProjection/index.vue
+++ b/app/src/components/parameterProjection/index.vue
@@ -8,9 +8,7 @@
 <template>
   <v-card :id="id">
     <v-layout class="chip-container">
-      <v-chip class="chip" chips color="teal" label outlined clearable>
-        {{ message }}
-      </v-chip>
+		<InfoChip ref="InfoChip" :title="title" :summary="summary" />
     </v-layout>
     <svg :id="svgId"></svg>
   </v-card>
@@ -23,11 +21,17 @@ import * as d3 from "d3";
 // Local library
 import { lasso } from "lib/interactions/lasso";
 import * as utils from "lib/utils";
+
+import InfoChip from "../general/infoChip";
+
 import APIService from "lib/routing/APIService";
 import EventHandler from "lib/routing/EventHandler.js";
 
 export default {
 	name: "ParameterProjection",
+	components: {
+		InfoChip
+	},
 	props: [],
 	data: () => ({
 		id: "parameter-projection-view",
@@ -41,7 +45,8 @@ export default {
 		xMax: 0,
 		yMin: 0,
 		yMax: 0,
-		message: "Parameter Projection",
+		title: "Parameter Projection",
+		summary: "",
 		showMessage: false,
 		colorset: [
 			"#FF7F00",

--- a/app/src/components/sankey/index.vue
+++ b/app/src/components/sankey/index.vue
@@ -7,15 +7,7 @@
 
 <template>
   <div>
-    <v-layout class="chip-container">
-      <v-chip class="chip" chips color="teal" label outlined clearable>
-        {{ summaryChip }}
-      </v-chip>
-      <v-spacer></v-spacer>
-      <span class="component-info">
-        Encoding = {{ selectedMetric }} runtime.
-      </span>
-    </v-layout>
+	<InfoChip ref="InfoChip" :title="title" :summary="summary" :info="info" />
     <v-layout>
       <svg :id="id">
         <g id="container">
@@ -45,6 +37,7 @@ import APIService from "lib/routing/APIService.js";
 
 // General component imports
 import ColorMap from "../general/colormap";
+import InfoChip from "../general/infoChip";
 
 // Local component imports
 import Nodes from "./nodes";
@@ -58,6 +51,7 @@ export default {
 		Edges,
 		MiniHistograms,
 		ColorMap,
+		InfoChip
 	},
 	data: () => ({
 		graph: null,
@@ -76,12 +70,13 @@ export default {
 		height: null,
 		treeHeight: null,
 		data: null,
-		message: "Summary Graph View",
 		sankeyWidth: 0,
 		sankeyHeight: 0,
-		summaryChip: "SuperGraph",
 		selectedMetric: "",
 		existingIntermediateNodes: {},
+		title: "Super Graph View",
+		message: "",
+		info: ""
 	}),
 
 	mounted() {
@@ -106,7 +101,7 @@ export default {
 			self.init();
 		});
 
-		this.selectedMetric = this.$store.selectedMetric;
+		this.selectedMetric = this.$store.selectedMetric;		
 	},
 
 	methods: {
@@ -145,6 +140,9 @@ export default {
 		},
 
 		async init() {
+			// set the component info.
+			this.info = "Encoding: " + this.$store.selectedMetric + " runtime";
+
 			this.data = await this.fetchData();
 			this.width = this.$store.viewWidth;
 			this.height = this.$store.viewHeight;

--- a/app/src/components/singleHistogram/index.vue
+++ b/app/src/components/singleHistogram/index.vue
@@ -7,11 +7,7 @@
 
 <template>
   <v-layout row wrap :id="id">
-    <v-layout class="chip-container">
-      <v-chip class="chip" chips color="teal" label outlined clearable>
-        {{ message }}
-      </v-chip>
-    </v-layout>
+	<InfoChip ref="InfoChip" :title="title" :summary="summary" />
     <svg :id="svgID"></svg>
     <ToolTip ref="ToolTip" />
   </v-layout>
@@ -27,6 +23,8 @@ import { brush } from "d3";
 import * as utils from "lib/utils";
 import EventHandler from "lib/routing/EventHandler";
 
+import InfoChip from "../general/infoChip";
+
 // Local component imports
 import ToolTip from "./tooltip";
 
@@ -34,6 +32,7 @@ export default {
 	name: "SingleHistogram",
 	components: {
 		ToolTip,
+		InfoChip
 	},
 	props: [],
 	data: () => ({
@@ -57,11 +56,12 @@ export default {
 		freq: [],
 		selectedColorBy: "Inclusive",
 		MPIcount: 0,
-		message: "MPI Runtime Distribution",
 		paddingFactor: 3.5,
 		boxOffset: 20,
 		x_max_exponent: 0,
 		superscript: "⁰¹²³⁴⁵⁶⁷⁸⁹",
+		title: "MPI Runtime Distribution",
+		summary: "",
 	}),
 
 	mounted() {

--- a/app/src/components/singleScatterplot/index.vue
+++ b/app/src/components/singleScatterplot/index.vue
@@ -7,11 +7,7 @@
 
 <template>
   <v-layout row wrap :id="id">
-    <v-layout class="chip-container">
-      <v-chip class="chip" chips color="teal" label outlined clearable>
-        {{ message }}
-      </v-chip>
-    </v-layout>
+    <InfoChip ref="InfoChip" :title="title" :summary="summary" />
     <span class="component-info"> Correlation : {{ corr_coef }} </span>
     <svg :id="svgID"></svg>
     <ToolTip ref="ToolTip" />
@@ -26,6 +22,8 @@ import * as d3 from "d3";
 import EventHandler from "lib/routing/EventHandler";
 import * as utils from "lib/utils";
 
+import InfoChip from "../general/infoChip";
+
 // Local components
 import ToolTip from "./tooltip";
 
@@ -33,6 +31,7 @@ export default {
 	name: "SingleScatterplot",
 	components: {
 		ToolTip,
+		InfoChip
 	},
 	data: () => ({
 		padding: {
@@ -52,7 +51,6 @@ export default {
 		boxWidth: 0,
 		id: "scatterplot-view",
 		svgID: "scatterplot-view-svg",
-		message: "MPI Runtime Scatterplot",
 		boxOffset: 20,
 		superscript: "⁰¹²³⁴⁵⁶⁷⁸⁹",
 		paddingFactor: 3.5,
@@ -61,6 +59,9 @@ export default {
 		corr_coef: 0,
 		xAxisHeight: 0,
 		yAxisHeight: 0,
+		title: "MPI Runtime Scatterplot",
+		summary: "",
+		info: ""
 	}),
 
 	mounted() {


### PR DESCRIPTION
This PR abstracts the `<v-chip>` component outside to `General` folder and creates a more generalized `InfoChip` component. 

Additionally, all component entry files are corrected to `index.vue`. 

Adding the summary information will be part of a separate PR. 