### PR TITLE
Performance improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,22 +27,22 @@ jobs:
     - stage: "tests"
       script:
         - echo -e "Running test (caliper-simple-json)"
-        - callflow --process --data_path ./data/caliper-simple-json --profile_format caliper_json
+        - callflow --process --reset --data_path ./data/caliper-simple-json --profile_format caliper_json
 
         - echo -e "Running test (caliper-lulesh-json)"
-        - callflow --process --data_path ./data/caliper-lulesh-json --profile_format caliper_json
+        - callflow --process --reset --data_path ./data/caliper-lulesh-json --profile_format caliper_json
 
         - echo -e "Running test (caliper-simple-cali)"
-        - callflow --process --data_path ./data/caliper-simple-cali --profile_format caliper
+        - callflow --process --reset --data_path ./data/caliper-simple-cali --profile_format caliper
 
         - echo -e "Running test (caliper-lulesh-cali)"
-        - callflow --process --data_path ./data/caliper-lulesh-cali --profile_format caliper
+        - callflow --process --reset --data_path ./data/caliper-lulesh-cali --profile_format caliper
 
         - echo -e "Running test (hpctoolkit-cpi-database)"
-        - callflow --process --data_path ./data/hpctoolkit-cpi-database --profile_format hpctoolkit
+        - callflow --process --reset --data_path ./data/hpctoolkit-cpi-database --profile_format hpctoolkit
 
         - echo -e "Running test (hpctoolkit-allgather-database)"
-        - callflow --process --data_path ./data/hpctoolkit-allgather-database --profile_format hpctoolkit
+        - callflow --process --reset --data_path ./data/hpctoolkit-allgather-database --profile_format hpctoolkit
 
     - stage: "style check"
       install: skip

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -338,8 +338,11 @@ class SuperGraph(ht.GraphFrame):
         _indexes = ["module"] + self.indexes
         _df = self.dataframe.set_index(_indexes)
 
-        return {_: _df.xs(_, 0)["name"].unique()
-                for _ in modules}
+        if "rank" in self.indexes:
+            return {_: _df.xs(_, 0)["name"].unique()
+                    for _ in modules}
+        else:
+            return {_: _df.xs(_, 0)["name"] for _ in modules}
 
     def df_callsite2mod(self, callsites = None):
 
@@ -349,18 +352,19 @@ class SuperGraph(ht.GraphFrame):
             assert isinstance(callsites, (list, np.ndarray))
 
         # TODO: this is a hack for now to append a "rank" index. 
-        if len(self.indexes) == 0:
+        if len(self.indexes) == 0 and "rank" in self.dataframe.columns:
             self.indexes = ["rank"]
         _indexes = ["name"] + self.indexes
         _df = self.dataframe.set_index(_indexes)
 
         map = {}
         for _ in callsites:
-            __df =  _df.xs(_, 0)
-            mod_idx = __df["module"].unique()
-            # assert mod_idx.shape[0] in [0, 1]
-            if mod_idx.shape[0] == 1:
-                map[_] = mod_idx[0]
+            if "rank" in self.indexes:
+                __df =  _df.xs(_, 0)
+                mod_idx = __df["module"].unique()
+                # assert mod_idx.shape[0] in [0, 1]
+                if mod_idx.shape[0] == 1:
+                    map[_] = mod_idx[0]
         return map
 
     # --------------------------------------------------------------------------

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -167,7 +167,7 @@ class SuperGraph(ht.GraphFrame):
         self.df_add_column("callers", apply_func=lambda _: self.callers[_])
         self.df_add_column("path", apply_func=lambda _: self.paths[_])
 
-        self.modules = np.array(self.df_factorize_column("module", sanitize=True))  # As expensive as 
+        self.modules = np.array(self.df_factorize_column("module", sanitize=True))
 
         self.profiler.stop()
         print(self.profiler.output_text(unicode=True, color=True))       
@@ -207,9 +207,9 @@ class SuperGraph(ht.GraphFrame):
             self.aux_data = UnpackAuxiliary(path, self.name).result
             # TODO: this should be handled better
             if "modules" in self.aux_data.keys():   # single case
-                self.modules = self.aux_data["modules"].tolist()
+                self.modules = self.aux_data["modules"]
             elif self.name in self.aux_data.keys():     # ensemble base
-                self.modules = self.aux_data[self.name]["modules"].tolist()
+                self.modules = self.aux_data[self.name]["modules"]
 
         # ----------------------------------------------------------------------
         self.add_time_proxies()
@@ -334,6 +334,10 @@ class SuperGraph(ht.GraphFrame):
         else:
             assert isinstance(modules, (list, np.ndarray))
 
+        # TODO: this is a hack for now to append a "rank" index. 
+        if len(self.indexes) == 0:
+            self.indexes = ["rank"]
+            
         _indexes = ["module"] + self.indexes
         _df = self.dataframe.set_index(_indexes)
 
@@ -347,6 +351,9 @@ class SuperGraph(ht.GraphFrame):
         else:
             assert isinstance(callsites, (list, np.ndarray))
 
+        # TODO: this is a hack for now to append a "rank" index. 
+        if len(self.indexes) == 0:
+            self.indexes = ["rank"]
         _indexes = ["name"] + self.indexes
         _df = self.dataframe.set_index(_indexes)
 
@@ -665,7 +672,6 @@ class SuperGraph(ht.GraphFrame):
 
         gf = None
         if profile_format == "hpctoolkit":
-            print(data_path)
             gf = ht.GraphFrame.from_hpctoolkit(data_path)
 
         elif profile_format == "caliper":

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -174,6 +174,17 @@ class SuperGraph(ht.GraphFrame):
 
 
     # --------------------------------------------------------------------------
+    def check_load(self, path):
+        dataset = os.path.basename(path)
+        for f_type, f_name in SuperGraph._FILENAMES.items():
+            ext = os.path.splitext(SuperGraph._FILENAMES[f_type])[-1]
+            if f_type == "aux":
+                f_name = f_name.format(dataset)
+
+            if not os.path.isfile(os.path.join(path, f_name)):
+                return False
+        return True
+    
     def load(
         self, path, read_graph=False, read_parameter=False, read_aux=False
     ) -> None:
@@ -242,8 +253,7 @@ class SuperGraph(ht.GraphFrame):
                 for c in clist:
                     self.callsite_module_map[c] = m
 
-            df_add_column(self.dataframe, "module", apply_on="name", lookup_dict=self.callsite_module_map)
-
+            self.df_add_column("module", apply_func=lambda _: self.callsite_module_map[_])
         # ----------------------------------------------------------------------
         else:
             LOGGER.info('No module map found. Defaulting to "module=callsite"')

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -159,14 +159,13 @@ class SuperGraph(ht.GraphFrame):
         for node in self.graph.traverse():
             node_name = Sanitizer.from_htframe(node.frame)
             self.hatchet_nodes[node_name] = node
-            self.paths[node_name] = node.paths()
+            self.paths[node_name] = [ Sanitizer.from_htframe(_) for _ in node.paths()[0]]
             self.callers[node_name] = [_.frame.get("name") for _ in node.parents]
             self.callees[node_name] = [_.frame.get("name") for _ in node.children]
 
         self.df_add_column("callees", apply_func=lambda _: self.callees[_])
         self.df_add_column("callers", apply_func=lambda _: self.callers[_])
-        self.df_add_column("path", apply_func=lambda _: [[
-            Sanitizer.from_htframe(_f) for _f in f] for f in self.paths[_]][0]) # Expensive.
+        self.df_add_column("path", apply_func=lambda _: self.paths[_])
 
         self.modules = np.array(self.df_factorize_column("module", sanitize=True))  # As expensive as 
 
@@ -243,8 +242,7 @@ class SuperGraph(ht.GraphFrame):
                 for c in clist:
                     self.callsite_module_map[c] = m
 
-            self.df_add_column("module",
-                               apply_func=lambda _: self.callsite_module_map[_])
+            df_add_column(self.dataframe, "module", apply_on="name", lookup_dict=self.callsite_module_map)
 
         # ----------------------------------------------------------------------
         else:

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -174,17 +174,6 @@ class SuperGraph(ht.GraphFrame):
 
 
     # --------------------------------------------------------------------------
-    def check_load(self, path):
-        dataset = os.path.basename(path)
-        for f_type, f_name in SuperGraph._FILENAMES.items():
-            ext = os.path.splitext(SuperGraph._FILENAMES[f_type])[-1]
-            if f_type == "aux":
-                f_name = f_name.format(dataset)
-
-            if not os.path.isfile(os.path.join(path, f_name)):
-                return False
-        return True
-    
     def load(
         self, path, read_graph=False, read_parameter=False, read_aux=False
     ) -> None:

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -337,7 +337,10 @@ class SuperGraph(ht.GraphFrame):
         else:
             assert isinstance(modules, (list, np.ndarray))
 
-        return {_: df_lookup_and_list(self.dataframe, "module", _, "name")
+        _indexes = ["module"] + self.indexes
+        _df = self.dataframe.set_index(_indexes)
+
+        return {_: _df.xs(_, 0)["name"].unique()
                 for _ in modules}
 
     def df_callsite2mod(self, callsites = None):
@@ -352,9 +355,9 @@ class SuperGraph(ht.GraphFrame):
 
         map = {}
         for _ in callsites:
-            __df =  _df.xs(callsites[0], 0)
+            __df =  _df.xs(_, 0)
             mod_idx = __df["module"].unique()
-            assert mod_idx.shape[0] in [0, 1]
+            # assert mod_idx.shape[0] in [0, 1]
             if mod_idx.shape[0] == 1:
                 map[_] = mod_idx[0]
         return map

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -21,7 +21,6 @@ from callflow.utils.utils import NumpyEncoder
 from callflow.utils.df import *
 from .metrics import FILE_FORMATS, METRIC_PROXIES, TIME_COLUMNS
 from callflow.modules import UnpackAuxiliary
-from pyinstrument import Profiler
 
 LOGGER = get_logger(__name__)
 
@@ -70,7 +69,6 @@ class SuperGraph(ht.GraphFrame):
         self.callsite_module_map = {}
         self.module_callsite_map = {}
         self.roots = []
-        self.profiler = Profiler()
 
     # --------------------------------------------------------------------------
     def __str__(self):
@@ -97,8 +95,6 @@ class SuperGraph(ht.GraphFrame):
         :param module_callsite_map: Module callsite mapping
         :return:
         """
-        self.profiler.start()
-        self.profile_format = profile_format
         LOGGER.info(f"Creating SuperGraph ({self.name}) from ({path}) "
                     f"using ({self.profile_format}) format")
 
@@ -169,10 +165,6 @@ class SuperGraph(ht.GraphFrame):
 
         self.modules = np.array(self.df_factorize_column("module", sanitize=True))
 
-        self.profiler.stop()
-        print(self.profiler.output_text(unicode=True, color=True))       
-
-
     # --------------------------------------------------------------------------
     def load(
         self, path, read_graph=False, read_parameter=False, read_aux=False
@@ -213,7 +205,8 @@ class SuperGraph(ht.GraphFrame):
 
         # ----------------------------------------------------------------------
         self.add_time_proxies()
-        self.df_reset_index()
+        # self.df_reset_index() # TODO: This might be cause a possible side
+        # effect. Beware!!
         self.roots = self.get_roots(self.nxg)
 
     # --------------------------------------------------------------------------

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -132,7 +132,7 @@ class SuperGraph(ht.GraphFrame):
         # ----------------------------------------------------------------------
         # Hatchet requires node and rank to be indexes.
         # remove the indexes to maintain consistency.
-        self.indexes = list(self.dataframe.index.names)
+        self.indexes = list(self.dataframe.index.names) # We will remove node since it gets droped when `gf.drop_index_levels()`
         self.df_reset_index()
 
         # ----------------------------------------------------------------------
@@ -347,10 +347,14 @@ class SuperGraph(ht.GraphFrame):
         else:
             assert isinstance(callsites, (list, np.ndarray))
 
+        _indexes = ["name"] + self.indexes
+        _df = self.dataframe.set_index(_indexes)
+
         map = {}
         for _ in callsites:
-            mod_idx = df_lookup_and_list(self.dataframe, "name", _, "module")
-            # assert mod_idx.shape[0] in [0, 1]
+            __df =  _df.xs(callsites[0], 0)
+            mod_idx = __df["module"].unique()
+            assert mod_idx.shape[0] in [0, 1]
             if mod_idx.shape[0] == 1:
                 map[_] = mod_idx[0]
         return map

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -95,6 +95,7 @@ class SuperGraph(ht.GraphFrame):
         :param module_callsite_map: Module callsite mapping
         :return:
         """
+        self.profile_format = profile_format
         LOGGER.info(f"Creating SuperGraph ({self.name}) from ({path}) "
                     f"using ({self.profile_format}) format")
 
@@ -322,15 +323,18 @@ class SuperGraph(ht.GraphFrame):
     # we need this
     def df_mod2callsite(self, modules = None):
 
+        if None in self.indexes:
+            LOGGER.error('Found None in indexes. Removing!')
+            self.indexes = [_ for _ in self.indexes if _ is not None]
+
         if modules is None:
             modules = self.df_unique("module")
         else:
             assert isinstance(modules, (list, np.ndarray))
 
-        # TODO: this is a hack for now to append a "rank" index. 
-        if len(self.indexes) == 0:
+        # TODO: this is a hack for now to append a "rank" index.
+        if len(self.indexes) == 0 and "rank" in self.dataframe.columns:
             self.indexes = ["rank"]
-            
         _indexes = ["module"] + self.indexes
         _df = self.dataframe.set_index(_indexes)
 

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -95,6 +95,7 @@ class SuperGraph(ht.GraphFrame):
         :param module_callsite_map: Module callsite mapping
         :return:
         """
+        self.profile_format = profile_format
         LOGGER.info(f"Creating SuperGraph ({self.name}) from ({path}) "
                     f"using ({self.profile_format}) format")
 

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -105,7 +105,7 @@ class SuperGraph(ht.GraphFrame):
         gf = SuperGraph.from_config(path, self.profile_format)
         assert isinstance(gf, ht.GraphFrame)
         assert gf.graph is not None
-        LOGGER.debug("Input Dataframe shape", gf.dataframe.shape)
+        LOGGER.debug(f"Input Dataframe shape: {gf.dataframe.shape}")
 
         super().__init__(gf.graph, gf.dataframe, gf.exc_metrics, gf.inc_metrics) # Initialize here so that we dont drop index levels.
 
@@ -350,7 +350,7 @@ class SuperGraph(ht.GraphFrame):
         map = {}
         for _ in callsites:
             mod_idx = df_lookup_and_list(self.dataframe, "name", _, "module")
-            assert mod_idx.shape[0] in [0, 1]
+            # assert mod_idx.shape[0] in [0, 1]
             if mod_idx.shape[0] == 1:
                 map[_] = mod_idx[0]
         return map

--- a/callflow/layout/sankey.py
+++ b/callflow/layout/sankey.py
@@ -487,7 +487,7 @@ class SankeyLayout:
                         "source_callsite": source["callsite"],
                         "target_callsite": target["callsite"],
                         "edge_type": edge_type,
-                        "weight": self._get_runtime(target, self.time_inc, 'mean'),
+                        "weight": self._get_runtime(target, "time (inc)", 'mean'),
                         "dataset": self.sg.name,
                     }
 

--- a/callflow/modules/auxiliary.py
+++ b/callflow/modules/auxiliary.py
@@ -58,7 +58,7 @@ class Auxiliary:
         # single super graph
         if not isinstance(sg, callflow.EnsembleGraph):
 
-            _df = df_bi_level_group(sg.dataframe, "module", "rank", cols=["time", "time (inc)", "name", "module"], apply_func=lambda _: _.mean())
+            _df = df_bi_level_group(sg.dataframe, "module", "rank", cols= self.time_columns + ["name", "module"], apply_func=lambda _: _.mean())
             df_module = _df.groupby("module")
             df_name = df_group_by(sg.dataframe, "name")
 
@@ -74,7 +74,7 @@ class Auxiliary:
         # ----------------------------------------------------------------------
         # ensemble graph
         else:
-            edf = df_bi_level_group(sg.dataframe, "module", "rank", cols=["time", "time (inc)", "name", "module"], apply_func=lambda _: _.mean())
+            edf = df_bi_level_group(sg.dataframe, "module", "rank", cols= self.time_columns + ["name", "module"], apply_func=lambda _: _.mean())
             edf_module = edf.groupby("module")
             
             edf_name = df_group_by(sg.dataframe, "name")

--- a/callflow/modules/auxiliary.py
+++ b/callflow/modules/auxiliary.py
@@ -16,7 +16,7 @@ from scipy.stats import kurtosis, skew
 import callflow
 from callflow.utils.utils import print_dict_recursive
 from callflow.utils.df import df_minmax, df_count, df_unique, df_group_by, \
-    df_fetch_columns, df_lookup_by_column, df_lookup_and_list, df_bi_level_group
+    df_fetch_columns, df_lookup_by_column, df_bi_level_group
 
 from .gradients import Gradients
 from .boxplot import BoxPlot

--- a/callflow/operations/filter.py
+++ b/callflow/operations/filter.py
@@ -64,7 +64,6 @@ class Filter:
 
         if self.filter_by == "time (inc)":
             value = self.filter_perc * 0.01 * np.max(max_vals["time (inc)"])
-            print(value)
             self._filter_sg(self.filter_by, value)
 
         elif self.filter_by == "time":
@@ -84,7 +83,7 @@ class Filter:
         self.dataframe = self.sg.df_filter_by_value(filter_by, filter_val)
         LOGGER.info(f'Filtered dataframe comprises of: "{self.dataframe.shape}"')
 
-        callsites = self.dataframe["name"].unique()
+        callsites = self.sg.f_callsites
         nxg = nx.DiGraph()
 
         if filter_by == "time (inc)":

--- a/callflow/utils/argparser.py
+++ b/callflow/utils/argparser.py
@@ -290,7 +290,7 @@ class ArgParser:
             "group_by",
             "read_parameter",
         ]:
-            scheme[_] = self.args[_]
+            scheme[_] = json[_]
 
         if len(scheme["save_path"]) == 0:
             scheme["save_path"] = os.path.join(scheme["data_path"], ".callflow")
@@ -321,7 +321,6 @@ class ArgParser:
             scheme["callsite_module_map"] = ArgParser._process_module_map(
                 json["module_callsite_map"]
             )
-
 
         return scheme
 

--- a/callflow/utils/argparser.py
+++ b/callflow/utils/argparser.py
@@ -171,6 +171,12 @@ class ArgParser:
             help="Path for logfile (stdout if no path is given)",
         )
 
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help="Resets the .callflow directory to re-process entire ensemble"
+        )
+
         # -------------
         return parser
 

--- a/callflow/utils/df.py
+++ b/callflow/utils/df.py
@@ -73,7 +73,7 @@ def df_lookup_by_column(df, column, value, proxy={}):
 def df_lookup_and_list(df, col_lookup, val_lookup, col_list, proxy={}):
     col_lookup = proxy.get(col_lookup, col_lookup)
     col_list = proxy.get(col_list, col_list)
-    return df_unique(df_lookup_by_column(df, col_lookup, val_lookup), col_list)
+    return np.array(list(set(df_lookup_by_column(df, col_lookup, val_lookup)[col_list].values)))
 
 
 # ------------------------------------------------------------------------------

--- a/server/main.py
+++ b/server/main.py
@@ -58,6 +58,7 @@ def main():
     process = args.args["process"]
     endpoint_access = args.args.get("endpoint_access", "REST")
     endpoint_env = args.args.get("endpoint_env", "TERMINAL")
+    reset = args.args["reset"]
 
     assert endpoint_access in ["REST", "SOCKETS"]
     assert endpoint_env in ["TERMINAL", "JUPYTER"]
@@ -68,7 +69,7 @@ def main():
         assert endpoint_env == "TERMINAL"
         cf = BaseProvider(config=args.config)
         LOGGER.profile(f'-----> Created BaseProvider')
-        cf.process()
+        cf.process(reset)
         LOGGER.profile(f'-----> Processed BaseProvider')
 
     # --------------------------------------------------------------------------

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -72,7 +72,7 @@ class BaseProvider:
                 LOGGER.warning(f"Duplicating aux data for run {name}!")
                 self.supergraphs[name].modules = self.supergraphs["ensemble"].modules
                 self.supergraphs[name].aux_data = self.supergraphs["ensemble"].aux_data[name]
-                
+
     def _process_load(self):
         # TODO: This is a copy and also exists in supergraph.py. 
         # Not quite sure where this should reside to avoid duplication.
@@ -95,7 +95,7 @@ class BaseProvider:
                 f_path = os.path.join(_path, f_run)
                 if not os.path.isfile(f_path):
                     process = True
-                
+
             if (process):
                 ret.append(dataset)
             else:
@@ -113,7 +113,6 @@ class BaseProvider:
         variables, e.g., filter_perc, filter_by.
         2. EnsembleGraph is then constructed from the processed SuperGraphs.
         """
-
         save_path = self.config["save_path"]
         load_path = self.config["data_path"]
         group_by = self.config["group_by"]
@@ -136,6 +135,7 @@ class BaseProvider:
             process_datasets, load_datasets = self.config["runs"], []
         else:
             process_datasets, load_datasets = self._process_load()
+
         LOGGER.info(f"Processing {len(process_datasets)} datasets.")
         LOGGER.info(f"Loading {len(load_datasets)} datasets.")
 
@@ -146,9 +146,9 @@ class BaseProvider:
             name = dataset["name"]
             _prop = run_props[name]
 
-            LOGGER.profile(f'Starting supergraph {name}')
+            LOGGER.profile(f'Starting supergraph ({name})')
 
-            sg = SuperGraph(name)        
+            sg = SuperGraph(name)
             sg.create(
                     path=os.path.join(load_path, _prop[0]),
                     profile_format=_prop[1],

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -148,10 +148,11 @@ class BaseProvider:
             Unify(sg, self.supergraphs)
             LOGGER.profile(f'Created supergraph {name}')
 
-            Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
-            LOGGER.profile(f'Filtered supergraph {name}')
             Group(sg, group_by=group_by)
             LOGGER.profile(f'Grouped supergraph {name}')
+
+            Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
+            LOGGER.profile(f'Filtered supergraph {name}')
 
             Auxiliary(sg)
             LOGGER.profile(f'Created Aux for {name}')

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -14,7 +14,6 @@ from callflow.modules import Auxiliary
 from callflow.layout import NodeLinkLayout, SankeyLayout, HierarchyLayout
 from callflow.modules import ParameterProjection, DiffView
 from callflow.utils.utils import get_memory_usage
-from pyinstrument import Profiler
 
 LOGGER = get_logger(__name__)
 
@@ -148,8 +147,6 @@ class BaseProvider:
             _prop = run_props[name]
 
             LOGGER.profile(f'Starting supergraph {name}')
-            profile = Profiler()
-            profile.start()
 
             sg = SuperGraph(name)        
             sg.create(
@@ -172,8 +169,6 @@ class BaseProvider:
             LOGGER.profile(f'Created Aux for {name}')
             sg.write(os.path.join(save_path, name), write_aux=(is_not_ensemble or indivdual_aux_for_ensemble))
 
-            profile.stop()
-            print(profile.output_text(unicode=True, color=True))
             self.supergraphs[name] = sg
             LOGGER.profile(f'Stored in dictionary {name}')
 

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -116,8 +116,6 @@ class BaseProvider:
                 filter_by=filter_by, filter_perc=filter_perc
             )
 
-
-            
             LOGGER.profile(f'Created supergraph {name}')
             Group(sg, group_by=group_by)
             LOGGER.profile(f'Grouped supergraph {name}')

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -109,26 +109,32 @@ class BaseProvider:
             profile.start()
 
             sg = SuperGraph(name)
-            sg.create(
-                path=os.path.join(load_path, _prop[0]),
-                profile_format=_prop[1],
-                module_callsite_map=module_callsite_map,
-                filter_by=filter_by, filter_perc=filter_perc
-            )
+            # TODO: Add a re-process mode.
+            read_param = self.config["read_parameter"]
+            read_aux = False
+            if(not sg.check_load(os.path.join(save_path, name))):
+                LOGGER.info("Not creating new directories!!! Moving on.")
+            else:
+                sg.create(
+                        path=os.path.join(load_path, _prop[0]),
+                        profile_format=_prop[1],
+                        module_callsite_map=module_callsite_map,
+                        filter_by=filter_by, filter_perc=filter_perc
+                    )
 
-            LOGGER.profile(f'Created supergraph {name}')
-            Group(sg, group_by=group_by)
-            LOGGER.profile(f'Grouped supergraph {name}')
+                LOGGER.profile(f'Created supergraph {name}')
+                Group(sg, group_by=group_by)
+                LOGGER.profile(f'Grouped supergraph {name}')
 
-            Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
-            LOGGER.profile(f'Filtered supergraph {name}')
-            
-            if is_not_ensemble or indivdual_aux_for_ensemble:
-                Auxiliary(sg)
+                Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
+                LOGGER.profile(f'Filtered supergraph {name}')
 
-            LOGGER.profile(f'Created Aux for {name}')
-            sg.write(os.path.join(save_path, name), write_aux=is_not_ensemble)
+                if (is_not_ensemble or indivdual_aux_for_ensemble) or True:
+                    Auxiliary(sg)
 
+                LOGGER.profile(f'Created Aux for {name}')
+                sg.write(os.path.join(save_path, name), write_aux=is_not_ensemble)
+ 
             profile.stop()
             print(profile.output_text(unicode=True, color=True))
             self.supergraphs[name] = sg

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -14,6 +14,7 @@ from callflow.modules import Auxiliary
 from callflow.layout import NodeLinkLayout, SankeyLayout, HierarchyLayout
 from callflow.modules import ParameterProjection, DiffView
 from callflow.utils.utils import get_memory_usage
+from pyinstrument import Profiler
 
 LOGGER = get_logger(__name__)
 
@@ -104,6 +105,8 @@ class BaseProvider:
             _prop = run_props[name]
 
             LOGGER.profile(f'Starting supergraph {name}')
+            profile = Profiler()
+            profile.start()
 
             sg = SuperGraph(name)
             sg.create(
@@ -128,6 +131,8 @@ class BaseProvider:
             LOGGER.profile(f'Created Aux for {name}')
             sg.write(os.path.join(save_path, name), write_aux=is_not_ensemble)
 
+            profile.stop()
+            print(profile.output_text(unicode=True, color=True))
             self.supergraphs[name] = sg
             LOGGER.profile(f'Stored in dictionary {name}')
 

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -100,6 +100,7 @@ class BaseProvider:
         LOGGER.warning(f'-------------------- PROCESSING {len(self.config["runs"])} SUPERGRAPHS --------------------\n\n\n')
 
         for dataset in self.config["runs"]:
+            print(dataset)
 
             name = dataset["name"]
             _prop = run_props[name]
@@ -112,12 +113,16 @@ class BaseProvider:
                 profile_format=_prop[1],
                 module_callsite_map=module_callsite_map,
             )
+            
+            Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
+            LOGGER.profile(f'Filtered supergraph {name}')
+
+            sg.post_filter()
+            # exit()
+
             LOGGER.profile(f'Created supergraph {name}')
             Group(sg, group_by=group_by)
             LOGGER.profile(f'Grouped supergraph {name}')
-
-            Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
-            LOGGER.profile(f'Filtered supergraph {name}')
             
             if is_not_ensemble or indivdual_aux_for_ensemble:
                 Auxiliary(sg)

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -100,8 +100,6 @@ class BaseProvider:
         LOGGER.warning(f'-------------------- PROCESSING {len(self.config["runs"])} SUPERGRAPHS --------------------\n\n\n')
 
         for dataset in self.config["runs"]:
-            print(dataset)
-
             name = dataset["name"]
             _prop = run_props[name]
 
@@ -112,17 +110,17 @@ class BaseProvider:
                 path=os.path.join(load_path, _prop[0]),
                 profile_format=_prop[1],
                 module_callsite_map=module_callsite_map,
+                filter_by=filter_by, filter_perc=filter_perc
             )
+
+
             
-            Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
-            LOGGER.profile(f'Filtered supergraph {name}')
-
-            sg.post_filter()
-            # exit()
-
             LOGGER.profile(f'Created supergraph {name}')
             Group(sg, group_by=group_by)
             LOGGER.profile(f'Grouped supergraph {name}')
+
+            Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
+            LOGGER.profile(f'Filtered supergraph {name}')
             
             if is_not_ensemble or indivdual_aux_for_ensemble:
                 Auxiliary(sg)


### PR DESCRIPTION
This PR improves the performance improvement to the processing pipeline.

1. Use time proxies for the `layout/node_link` and `layout/sankey`.
2. Improve performance of `df.add_columns`. 
3. Improve performance of `df.mod2callsite` and `df.callsite2mod`.
4. Incorporate `Hatchet.QueryMatcher`.
5. Add `--reset` mode to the processing pipeline.
6. Delegate expensive operations after filtering the supergraphs. 