### PR TITLE
Minor features

### DIFF
--- a/app/src/components/SuperGraphEnsemble.vue
+++ b/app/src/components/SuperGraphEnsemble.vue
@@ -34,14 +34,14 @@
 		<splitpanes id="callgraph-dashboard-2" class="default-theme">
 			<!-- Left column-->
 			<splitpanes horizontal splitpanes-size="25">
-			<ModuleHierarchy ref="ModuleHierarchy" />
-			<EnsembleScatterplot ref="EnsembleScatterplot" />
-			<EnsembleHistogram ref="EnsembleHistogram" />
+				<ModuleHierarchy ref="ModuleHierarchy" />
+				<EnsembleScatterplot ref="EnsembleScatterplot" />
+				<EnsembleHistogram ref="EnsembleHistogram" />
 			</splitpanes>
 
 			<!-- Center column-->
 			<splitpanes horizontal splitpanes-size="55">
-			<Sankey ref="Sankey" />
+				<Sankey ref="Sankey" />
 			</splitpanes>
 
 			<!-- Right column-->

--- a/app/src/components/callsiteCorrespondence/boxplot.vue
+++ b/app/src/components/callsiteCorrespondence/boxplot.vue
@@ -71,7 +71,8 @@ export default {
 	
 	computed: {
 		...mapGetters({
-			generalColors: "getGeneralColors"
+			generalColors: "getGeneralColors",
+			targetColor: "getTargetColor"
 		})
 	},
 	components: {
@@ -107,7 +108,7 @@ export default {
 			this.tOutliers = this.tData["outliers"];
 			this.bOutliers = this.bData["outliers"];
 
-			this.tColor = this.generalColors.target;
+			this.tColor = this.targetColor;
 			this.bColor = this.generalColors.ensemble;
 
 			this.nid = this.tData["nid"];

--- a/app/src/components/callsiteCorrespondence/index_cc.vue
+++ b/app/src/components/callsiteCorrespondence/index_cc.vue
@@ -57,7 +57,7 @@
       v-for="callsite in intersectionCallsites"
       :key="getID(callsite.nid)"
     >
-      <v-row  class="pt-2">
+      <v-row>
         <!-- <v-col cols="1">
           <v-card class="ma-2 ml-4" tile outlined>
             <v-tooltip bottom>

--- a/app/src/components/callsiteInformation/index_ci.vue
+++ b/app/src/components/callsiteInformation/index_ci.vue
@@ -93,7 +93,6 @@ export default {
 		boxplotHeight: 340,
 		boxplotWidth: 0,
 		duration: 300,
-		iqrFactor: 0.15,
 		outlierRadius: 4,
 		outlierList: {},
 		callsiteIDMap: {},
@@ -122,7 +121,8 @@ export default {
 			selectedMetric: "getSelectedMetric",
 			data: "getSingleBoxplots",
 			summary: "getSummary",
-			runtimeSortBy: "getRuntimeSortBy"
+			runtimeSortBy: "getRuntimeSortBy",
+			iqrFactor: "getIQRFactor",
 		})
 	},
 
@@ -179,6 +179,7 @@ export default {
 				metric: this.selectedMetric,
 				callsites: callsites,
 				ntype: "callsite",
+				iqr: this.iqrFactor,
 			});
 
 			this.width = document.getElementById(this.id).clientWidth;

--- a/app/src/components/ensembleHistogram/index_eh.vue
+++ b/app/src/components/ensembleHistogram/index_eh.vue
@@ -73,7 +73,8 @@ export default {
 			showTarget: "getShowTarget",
 			generalColors: "getGeneralColors",
 			selectedProp: "getProp",
-			selectedRunBinCount: "getRunBinCount"
+			selectedRunBinCount: "getRunBinCount",
+			targetColor: "getTargetColor"
 		})
 	},
 
@@ -204,7 +205,7 @@ export default {
 					y: (d, i) => this.yScale(d),
 					width: this.xScale.bandwidth(),
 					height: (d) => Math.abs(this.yAxisHeight - this.yScale(d)),
-					fill: this.generalColors.target,
+					fill: this.targetColor,
 					opacity: 1,
 					"stroke-width": "0.2px",
 					stroke: "#202020",

--- a/app/src/components/ensembleHistogram/index_eh.vue
+++ b/app/src/components/ensembleHistogram/index_eh.vue
@@ -103,7 +103,7 @@ export default {
 
 			// Assign the height and width of container
 			this.width = window.innerWidth * 0.25;
-			this.height = this.$store.viewHeight * 0.33;
+			this.height = this.$store.viewHeight * 0.30;
 
 			// Assign width and height for histogram and rankLine SVG.
 			this.boxWidth = this.width - 1 * (this.padding.right + this.padding.left);

--- a/app/src/components/ensembleHistogram/index_eh.vue
+++ b/app/src/components/ensembleHistogram/index_eh.vue
@@ -132,7 +132,7 @@ export default {
 			if (this.showTarget) {
 				this.targetBars();
 			}
-			// this.$refs.ToolTip.init(this.svgID);
+			this.$refs.ToolTip.init(this.svgID);
 		},
 
 		setupScale() {

--- a/app/src/components/ensembleScatterplot/index_es.vue
+++ b/app/src/components/ensembleScatterplot/index_es.vue
@@ -75,6 +75,7 @@ export default {
 			summary: "getSummary",
 			showTarget: "getShowTarget",
 			generalColors: "getGeneralColors",
+			targetColor: "getTargetColor"
 		})
 	},
 
@@ -379,8 +380,8 @@ export default {
 						"cx": () => this.xScale(this.xtargetArray[i]) + 3 * this.padding.left,
 						"cy": (d, i) => this.yScale(self.ytargetArray[i]),
 					})
-					.style("fill", this.generalColors.target)
-					.style("stroke", this.generalColors.darkGrey)
+					.style("fill", this.targetColor)
+					// .style("stroke", this.generalColors.darkGrey)
 					.style("stroke-width", 0.5)
 					.on("mouseover", () => {
 						let data = {

--- a/app/src/components/ensembleScatterplot/index_es.vue
+++ b/app/src/components/ensembleScatterplot/index_es.vue
@@ -94,6 +94,7 @@ export default {
 
 	methods: {
 		init() {
+			this.orientation = ["time", "time (inc)"];
 			this.$store.dispatch("fetchEnsembleScatterplot", {
 				dataset: this.selectedTargetRun,
 				node: this.selectedNode["name"],
@@ -173,7 +174,7 @@ export default {
 
 			// this.correlationText()
 			this.setTitle();
-			// this.$refs.ToolTip.init(this.svgID);
+			this.$refs.ToolTip.init(this.svgID);
 		},
 
 		setTitle() {
@@ -286,7 +287,7 @@ export default {
 			var y1 = leastSquaresCoeff[0] * this.xMin + leastSquaresCoeff[1];
 			var x2 = this.xMax;
 			var y2 = leastSquaresCoeff[0] * this.xMax + leastSquaresCoeff[1];
-			var trendData = [[x1,y1,x2,y2]];
+			var trendData = [[x1, y1, x2, y2]];
 			
 			var trendline = this.svg.selectAll("#trendline" + id)
 				.data(trendData);
@@ -348,8 +349,10 @@ export default {
 						let data = {
 							"callsite": callsite,
 							"QCD": opacity,
-							"value": self.xArray[i].val,
-							"run": self.xArray[i].run
+							"x": self.xArray[i],
+							"y": self.yArray[i],
+							"run": self.xArray[i].run,
+							"orientation": self.orientation
 						};
 						self.$refs.ToolTip.render(data);
 					})
@@ -383,7 +386,9 @@ export default {
 						let data = {
 							"callsite": callsite,
 							"QCD": opacity,
-							"value": self.xtargetArray[i].val,
+							"x": self.xtargetArray[i],
+							"y": self.ytargetArray[i],
+							"orientation": self.orientation,
 							"run": run
 						};
 						self.$refs.ToolTip.render(data);

--- a/app/src/components/ensembleScatterplot/index_es.vue
+++ b/app/src/components/ensembleScatterplot/index_es.vue
@@ -104,7 +104,7 @@ export default {
 			});
 
 			this.width = window.innerWidth * 0.25;
-			this.height = (this.$store.viewHeight) * 0.33;
+			this.height = (this.$store.viewHeight) * 0.30;
 
 			this.boxWidth = this.width - this.padding.right - this.padding.left;
 			this.boxHeight = this.height - this.padding.top - this.padding.bottom;
@@ -381,7 +381,8 @@ export default {
 						"cy": (d, i) => this.yScale(self.ytargetArray[i]),
 					})
 					.style("fill", this.targetColor)
-					// .style("stroke", this.generalColors.darkGrey)
+					.style("opacity", 0.5)
+					.style("stroke", this.generalColors.darkGrey)
 					.style("stroke-width", 0.5)
 					.on("mouseover", () => {
 						let data = {

--- a/app/src/components/ensembleScatterplot/tooltip.vue
+++ b/app/src/components/ensembleScatterplot/tooltip.vue
@@ -12,6 +12,7 @@
 <script>
 import * as d3 from "d3";
 import * as utils from "lib/utils";
+import { mapGetters } from "vuex";
 
 export default {
 	name: "ToolTip",
@@ -25,6 +26,12 @@ export default {
 		fontSize: 12,
 	}),
 
+	computed: {
+		...mapGetters({
+			selectedMetric: "getSelectedMetric"
+		})
+	},
+
 	methods: {
 		init(id) {
 			this.id = id;
@@ -34,7 +41,7 @@ export default {
 				.attr("class", "toolTipSVG");
 
 			this.toolTipG = this.toolTipDiv.append("g");
-			this.height = 80;
+			this.height = 50;
 			this.halfWidth = document.getElementById(this.id).clientWidth / 2;
 			this.halfHeight = document.getElementById(this.id).clientHeight / 2;
 		},
@@ -85,23 +92,11 @@ export default {
 			return str.length > n ? str.substr(0, n - 1) + "..." : str;
 		},
 
-		truncTimeLabel(str) {
-			if (str == "Inclusive") {
-				return "Inc.";
-			} else if (str == "Exclusive") {
-				return "Exc.";
-			}
-		},
-
 		info() {
-			this.addText("Callsite: " + utils.truncNames(this.data.callsite, 10));
-			this.addText(
-				"Mean " +
-          this.truncTimeLabel(this.$store.selectedMetric) +
-          " Time: " +
-          utils.formatRuntimeWithUnits(this.data.value)
-			);
-			this.addText("Run: " + this.data.run);
+			// this.addText("Callsite: " + utils.truncNames(this.data.callsite, 10));
+			this.addText(this.data.orientation[0] + " : " + utils.formatRuntimeWithUnits(this.data.x));
+			this.addText(this.data.orientation[1] + " : " + utils.formatRuntimeWithUnits(this.data.y));
+			// this.addText("Run: " + this.data.run);
 			// this.addText('QCD: ' + this.data.QCD.toFixed(3))
 		},
 

--- a/app/src/components/general/colormap.vue
+++ b/app/src/components/general/colormap.vue
@@ -26,7 +26,7 @@ export default {
 		width: 230,
 		containerWidth: 660,
 		height: 20,
-		containerHeight: 50,
+		containerHeight: 100,
 		colorMin: 0,
 		colorMax: 0,
 		offset: 30,

--- a/app/src/components/general/settings/index.vue
+++ b/app/src/components/general/settings/index.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col class="pa-0">
     <v-flex xs12 class="ma-1">
-      <v-subheader class="teal lighten-4">Visual Encoding</v-subheader>
+      <v-subheader class="teal lighten-4">SuperGraph Encoding</v-subheader>
     </v-flex>
     <v-flex xs12 class="ma-1">
       <v-select
@@ -68,7 +68,7 @@
 
     <template :v-if="selectedMode == 'SG'">
       <v-flex xs12 class="ma-1">
-        <v-subheader class="teal lighten-4">Histograms</v-subheader>
+        <v-subheader class="teal lighten-4">Runtime Encoding</v-subheader>
       </v-flex>
 
       <v-flex xs12 class="ma-1" :v-show="selectedMode == 'SG'">
@@ -131,7 +131,7 @@
 
     <template>
       <v-flex xs12 class="ma-1">
-        <v-subheader class="teal lighten-4">Call site Information</v-subheader>
+        <v-subheader class="teal lighten-4">Call site Variability</v-subheader>
       </v-flex>
       <v-flex xs12 class="ma-1">
         <v-select
@@ -158,6 +158,7 @@
           :disabled="
             selectedMode === 'ESG' || selectedMode == 'SG' ? false : true
           "
+          @change="updateIQRFactor"
         >
         </v-text-field>
       </v-flex>
@@ -215,6 +216,7 @@ export default {
 			"updateTargetColor",
 			"updateCompareRun",
 			"updateProp",
+			"updateIQRFactor"
 		]),
 
 		init() {

--- a/app/src/components/general/settings/index.vue
+++ b/app/src/components/general/settings/index.vue
@@ -183,7 +183,6 @@ export default {
 		compareModes: ["MEAN_DIFF", "RANK_DIFF"],
 		selectedCompareMode: "MEAN_DIFF",
 		props: ["name", "rank", "dataset"],
-		targetColors: ["Green", "Blue", "Brown"],
 	}),
 
 	computed: {
@@ -200,7 +199,11 @@ export default {
 			selectedIQRFactor: "getIQRFactor",
 			selectedCompareRun: "getCompareRun",
 			selectedProp: "getProp",
+			targetColorMap: "getTargetColorMap"
 		}),
+		targetColors: function () {
+			return Object.keys(this.targetColorMap);
+		}
 	},
 
 	methods: {
@@ -213,7 +216,6 @@ export default {
 			"updateRankBinCount",
 			"updateRunBinCount",
 			"updateRuntimeSortBy",
-			"updateTargetColor",
 			"updateCompareRun",
 			"updateProp",
 			"updateIQRFactor"

--- a/app/src/components/moduleHierarchy/index.vue
+++ b/app/src/components/moduleHierarchy/index.vue
@@ -8,9 +8,6 @@
 <template>
   <v-layout row wrap :id="id">
 	<InfoChip ref="InfoChip" :title="title" :summary="infoSummary" :info="info"/>
-    <span class="component-info">
-      Module = {{ formatModule(selectedModule) }}
-    </span>
     <ToolTip ref="ToolTip" />
   </v-layout>
 </template>
@@ -111,6 +108,8 @@ export default {
 			self.clear();
 			self.init();
 		});
+
+		this.infoSummary = "Module: " + this.selectedNode["name"];
 	},
 
 	methods: {

--- a/app/src/components/moduleHierarchy/index.vue
+++ b/app/src/components/moduleHierarchy/index.vue
@@ -106,6 +106,11 @@ export default {
 			self.clear();
 			self.init();
 		});
+
+		EventHandler.$on("update-node-encoding", function() {
+			self.clear();
+			self.init();
+		});
 	},
 
 	methods: {
@@ -221,12 +226,11 @@ export default {
 		},
 
 		clear() {
-			// d3.selectAll(".icicleNode").remove();
-			// d3.selectAll(".icicleText").remove();
-			// d3.selectAll(".hierarchy-targetLines").remove();
-			// d3.selectAll(".linear-gradient").remove();
 			d3.select("#module-hierarchy-svg").remove();
-			// this.$refs.ToolTipModuleHierarchy.clear()
+		},
+
+		clearEncoding() {
+			d3.select(".hierarchy-gradient").remove();
 		},
 
 		descendents(root) {
@@ -461,7 +465,7 @@ export default {
 			const linearGradient = defs
 				.append("linearGradient")
 				.attr("id", "hierarchy-gradient" + nid)
-				.attr("class", "linear-gradient");
+				.attr("class", "hierarchy-gradient");
 
 			linearGradient
 				.attr("x1", "0%")

--- a/app/src/components/parameterProjection/index_pp.vue
+++ b/app/src/components/parameterProjection/index_pp.vue
@@ -62,6 +62,7 @@ export default {
 			summary: "getSummary",
 			selectedTargetRun: "getSelectedTargetRun",
 			generalColors: "getGeneralColors",
+			targetColor: "getTargetColor"
 		})
 	},
 
@@ -425,7 +426,7 @@ export default {
 			d3.select(
 				"#outer-dot" + this.selectedRun
 			)
-				.attr("stroke", self.generalColors.target)
+				.attr("stroke", this.targetColor)
 				.attr("stroke-width", 3);
 
 			// Set the local and global variables for compare dataset

--- a/app/src/components/sankey/encodings/meanGradients.vue
+++ b/app/src/components/sankey/encodings/meanGradients.vue
@@ -79,12 +79,13 @@ export default {
 
 			let nid = d.attr_dict.nid;
 
-			const defs = d3.select("#" + this.id).append("defs");
+			const defs = d3.select("#" + this.id)
+				.append("defs");
 
 			const linearGradient = defs
 				.append("linearGradient")
 				.attr("id", "mean-gradient" + nid)
-				.attr("class", "linear-gradient");
+				.attr("class", "mean-gradient");
 
 			linearGradient
 				.attr("x1", "0%")
@@ -107,7 +108,7 @@ export default {
 		},
 
 		clear() {
-			d3.select("#" + this.id).remove();
+			d3.selectAll(".mean-gradient").remove();
 		}
 	},
 };

--- a/app/src/components/sankey/encodings/targetLine.vue
+++ b/app/src/components/sankey/encodings/targetLine.vue
@@ -27,6 +27,7 @@ export default {
 			generalColors: "getGeneralColors",
 			selectedMetric: "getSelectedMetric",
 			selectedRunBinCount: "getRunBinCount",
+			targetColor: "getTargetColor",
 		})
 	},
 
@@ -52,7 +53,7 @@ export default {
 					"x2": this.$parent.nodeWidth,
 					"y2": (d) => this.getTargetPos(d),
 					"stroke-width": 5,
-					"stroke": this.generalColors.target
+					"stroke": this.targetColor
 				});
 		},
 

--- a/app/src/components/sankey/encodings/targetLine.vue
+++ b/app/src/components/sankey/encodings/targetLine.vue
@@ -33,7 +33,7 @@ export default {
 
 	methods: {
 		init(nodes, containerG) {
-			this.nodes = nodes;
+			this.nodes = nodes.filter((node) => !(node.type === "intermediate"));
 			this.containerG = containerG;
 			this.visualize();
 		},

--- a/app/src/components/sankey/index_sg.vue
+++ b/app/src/components/sankey/index_sg.vue
@@ -158,6 +158,15 @@ export default {
 			self.$refs.Nodes.$refs.TargetLine.clear();
 			self.$refs.MiniHistograms.clear();
 		});
+
+		EventHandler.$on("update-ensemble-colors", () => {
+			d3.selectAll(".callsite").remove();
+			self.$refs.ColorMap.clear();
+			self.singleColors();
+			self.ensembleColors();
+			self.$refs.Nodes.init(self.data);
+			this.colormaps();
+		});
 	},
 
 	methods: {
@@ -275,6 +284,10 @@ export default {
 			this.$refs.Edges.init(this.data);
 			this.$refs.MiniHistograms.init(this.data);
 
+			this.colormaps();
+		},
+
+		colormaps() {
 			if (this.selectedMode == "SG") {
 				this.$refs.ColorMap.init(this.$store.runtimeColor);
 			}

--- a/app/src/components/sankey/index_sg.vue
+++ b/app/src/components/sankey/index_sg.vue
@@ -161,9 +161,14 @@ export default {
 
 		EventHandler.$on("update-ensemble-colors", () => {
 			self.$refs.ColorMap.clear();
-			self.singleColors();
-			self.ensembleColors();
-			this.colormaps();
+			if (self.isComparisonMode) {
+				// EventHandler.$emit("setup-diff-colormap");
+			}
+			else {
+				self.singleColors();
+				self.ensembleColors();
+			}
+			this.initColorMaps();
 		});
 	},
 
@@ -282,16 +287,21 @@ export default {
 			this.$refs.Edges.init(this.data);
 			this.$refs.MiniHistograms.init(this.data);
 
-			this.colormaps();
+			this.initColorMaps();
 		},
 
-		colormaps() {
+		initColorMaps() {
 			if (this.selectedMode == "SG") {
 				this.$refs.ColorMap.init(this.$store.runtimeColor);
 			}
 			else if(this.selectedMode == "ESG") {
-				this.$refs.ColorMap.init(this.$store.runtimeColor);
-				this.$refs.ColorMap.init(this.$store.distributionColor);
+				if (this.isComparisonMode) {
+					this.$refs.ColorMap.init(this.$store.diffColor);
+				}
+				else {
+					this.$refs.ColorMap.init(this.$store.runtimeColor);
+					this.$refs.ColorMap.init(this.$store.distributionColor);
+				}
 			}
 		},
 

--- a/app/src/components/sankey/index_sg.vue
+++ b/app/src/components/sankey/index_sg.vue
@@ -160,11 +160,9 @@ export default {
 		});
 
 		EventHandler.$on("update-ensemble-colors", () => {
-			d3.selectAll(".callsite").remove();
 			self.$refs.ColorMap.clear();
 			self.singleColors();
 			self.ensembleColors();
-			self.$refs.Nodes.init(self.data);
 			this.colormaps();
 		});
 	},

--- a/app/src/components/sankey/miniHistograms.vue
+++ b/app/src/components/sankey/miniHistograms.vue
@@ -36,6 +36,7 @@ export default {
 			selectedMode: "getSelectedMode",
 			showTarget: "getShowTarget",
 			comparisonMode: "getComparisonMode",
+			targetColor: "getTargetColor"
 		})
 	},
 
@@ -80,7 +81,7 @@ export default {
 			}
 			else if (type == "target" || type == "single") {
 				if (type == "target")
-					color = this.generalColors.target;
+					color = this.targetColor;
 				else if (type == "single")
 					color = this.generalColors.intermediate;
 				xVals = data.x;

--- a/app/src/components/sankey/nodes.vue
+++ b/app/src/components/sankey/nodes.vue
@@ -78,8 +78,9 @@ export default {
 	mounted() {
 		let self = this;
 		EventHandler.$on("update-node-encoding", function (data) {
-			self.clear();
-			self.init(self.graph);
+			self.clearEncoding();
+			EventHandler.$emit("update-ensemble-colors");
+			self.visualize();
 		});
 	},
 

--- a/app/src/components/sankey/nodes.vue
+++ b/app/src/components/sankey/nodes.vue
@@ -128,8 +128,7 @@ export default {
 			this.ensemblePath();
 			this.text();
 
-			// TODO: Fix this.
-			if (this.showTarget && this.selectedMode === "ESG") {
+			if (this.showTarget && this.selectedMode === "ESG" && !this.isComparisonMode) {
 				this.$refs.TargetLine.init(this.graph.nodes, this.containerG);
 				this.$refs.Guides.init(this.graph.nodes, this.containerG);
 				this.targetPath();
@@ -222,7 +221,7 @@ export default {
 				const nodeSVG = this.containerG.select("#callsite-" + node.id);
 
 				// Make appropriate event requests (Single and Ensemble).
-				if (this.selectedMode == "ESG") {
+				if (this.selectedMode == "ESG" && !this.isComparisonMode) {
 					if (!this.drawGuidesMap[node.id]) {
 						this.$refs.Guides.visualize(node, "permanent", nodeSVG);
 						this.drawGuidesMap[node.id] = true;
@@ -243,14 +242,14 @@ export default {
 
 		mouseover(node) {
 			this.$refs.ToolTip.visualize(self.graph, node);
-			if (this.selectedMode === "ESG") {
+			if (this.selectedMode === "ESG" && !this.isComparisonMode) {
 				this.$refs.Guides.visualize(node, "temporary");
 			}
 		},
 
 		mouseout(node) {
 			this.$refs.ToolTip.clear();
-			if (this.$store.selectedMode == "Ensemble") {
+			if (this.selectedMode == "ESG") {
 				this.$refs.Guides.clear(node, "temporary");
 				if (this.permanentGuides == false) {
 					d3.selectAll(".ensemble-edge")

--- a/app/src/components/singleHistogram/index_sh.vue
+++ b/app/src/components/singleHistogram/index_sh.vue
@@ -182,40 +182,23 @@ export default {
 			this.$refs.ToolTip.clear();
 		},
 
-		
-
 		array_unique(arr) {
 			return arr.filter(function (value, index, self) {
 				return self.indexOf(value) === index;
 			});
 		},
 
-		dataProcess(data, mpiData) {
+		dataProcess(data) {
 			let axis_x = [];
-			let binContainsProcID = {};
 			let dataMin = data["x_min"];
 			let dataMax = data["x_max"];
 
-			const dataWidth = (dataMax - dataMin) / (data["x"].length);
+			const dataWidth = (dataMax - dataMin) / (data["x"].length - 1);
 			for (let i = 0; i < data["x"].length; i++) {
 				axis_x.push(dataMin + i * dataWidth);
 			}
 
-			// TODO: Expensive !!!
-			mpiData.forEach((val, idx) => {
-				let pos = Math.floor((val - dataMin) / dataWidth);
-				if (pos >= this.rankBinCount) {
-					pos = this.rankBinCount;
-				}
-				if (pos < 0){
-					pos = 0;
-				}
-				if (binContainsProcID[pos] == null) {
-					binContainsProcID[pos] = [];
-				}
-				binContainsProcID[pos].push(idx);
-			});
-			return [data["x"], data["y"], axis_x, binContainsProcID];
+			return [data["x"], data["y"], axis_x, data["dig"]];
 		},
 
 		removeDuplicates(arr) {
@@ -229,8 +212,6 @@ export default {
 		// return a string version and an array version
 		// stolen from this: https://gist.github.com/XciA/10572206
 		groupProcess(processIDs) {
-
-			console.log(processIDs);
 			const constData = processIDs.slice();
 			let a = 0;
 			let groupArrayStr = "[ ";
@@ -269,7 +250,7 @@ export default {
 					string = `[${constData[k]}]`;
 					temp.push(constData[k]);
 				}
-				groupArray.push(temp);
+				// groupArray.push(temp);
 				if (!first) {
 					groupArrayStr += ", ";
 				}
@@ -314,13 +295,13 @@ export default {
 					d3.selectAll(`.lineRank_${i}`)
 						.style("fill", "orange")
 						.style("fill-opacity", 1);
+
 					let groupProcStr = self.groupProcess(self.binContainsProcID[i])
 						.string;
 					groupProcStr =  "MPI ranks:" + self.sanitizeGroupProc(groupProcStr);
 					self.$refs.ToolTip.render(groupProcStr, d);
 				})
 				.on("mouseover", function (d, i) {
-					console.log(d);
 					d3.select(this).attr("fill", "orange");
 					d3.selectAll(".lineRank")
 						.style("fill-opacity", 0.1);
@@ -647,7 +628,6 @@ export default {
 				ranks: processIDList,
 				ntype: "callsite",
 			});
-			console.log(split_sgs);
 		},
 	},
 };

--- a/app/src/components/singleHistogram/index_sh.vue
+++ b/app/src/components/singleHistogram/index_sh.vue
@@ -177,7 +177,6 @@ export default {
 			d3.selectAll(".binRank").remove();
 			d3.selectAll(".lineRank").remove();
 			d3.selectAll(".brush").remove();
-			d3.selectAll(".tick").remove();
 			d3.selectAll(".histogram-rank-axis").remove();
 			this.$refs.ToolTip.clear();
 		},
@@ -474,11 +473,8 @@ export default {
 							end = group[1] + 1;
 						}
 
-						let topX1 = cumulativeBinSpace + binLocation + widthPerRank;
-						let topX2 =
-              cumulativeBinSpace +
-              (end - start + 1) * widthPerRank +
-              binLocation;
+						let topX1 = cumulativeBinSpace + binLocation + widthPerRank + binWidth  / 4;
+						let topX2 = cumulativeBinSpace + (end - start + 1) * widthPerRank + binLocation + binWidth / 4;
 
 						let botX3 = this.ranklinescale(start);
 						let botX4 = this.ranklinescale(end);
@@ -501,7 +497,7 @@ export default {
 								return "grey";
 							})
 							.style("fill-opacity", 0.4)
-							.attr("transform", `translate(${binWidth/2},${-3 * this.bottomMargin})`);
+							.attr("transform", `translate(${0},${-3 * this.bottomMargin})`);
 					});
 				}
 			});

--- a/app/src/components/singleHistogram/index_sh.vue
+++ b/app/src/components/singleHistogram/index_sh.vue
@@ -229,6 +229,8 @@ export default {
 		// return a string version and an array version
 		// stolen from this: https://gist.github.com/XciA/10572206
 		groupProcess(processIDs) {
+
+			console.log(processIDs);
 			const constData = processIDs.slice();
 			let a = 0;
 			let groupArrayStr = "[ ";
@@ -267,7 +269,7 @@ export default {
 					string = `[${constData[k]}]`;
 					temp.push(constData[k]);
 				}
-				// groupArray.push(temp);
+				groupArray.push(temp);
 				if (!first) {
 					groupArrayStr += ", ";
 				}
@@ -314,22 +316,25 @@ export default {
 						.style("fill-opacity", 1);
 					let groupProcStr = self.groupProcess(self.binContainsProcID[i])
 						.string;
-					groupProcStr =  "Processes (MPI ranks):" + self.sanitizeGroupProc(groupProcStr);
+					groupProcStr =  "MPI ranks:" + self.sanitizeGroupProc(groupProcStr);
 					self.$refs.ToolTip.render(groupProcStr, d);
 				})
 				.on("mouseover", function (d, i) {
+					console.log(d);
 					d3.select(this).attr("fill", "orange");
+					d3.selectAll(".lineRank")
+						.style("fill-opacity", 0.1);
 					d3.selectAll(`.lineRank_${i}`)
 						.style("fill", "orange")
 						.style("fill-opacity", 1);
 					let groupProcStr = self.groupProcess(self.binContainsProcID[i])
 						.string;
-					groupProcStr = "Processes (MPI ranks):" + self.sanitizeGroupProc(groupProcStr);
+					groupProcStr = d + " MPI ranks:" + self.sanitizeGroupProc(groupProcStr);
 					self.$refs.ToolTip.render(groupProcStr, d);
 				})
 				.on("mouseout", function (d, i) {
 					d3.select(this).attr("fill", self.generalColors.intermediate);
-					d3.selectAll(`.lineRank_${i}`)
+					d3.selectAll(".lineRank")
 						.style("fill", "grey")
 						.style("fill-opacity", 0.4);
 					self.$refs.ToolTip.clear();
@@ -515,7 +520,7 @@ export default {
 								return "grey";
 							})
 							.style("fill-opacity", 0.4)
-							.attr("transform", `translate(${0},${-3 * this.bottomMargin})`);
+							.attr("transform", `translate(${binWidth/2},${-3 * this.bottomMargin})`);
 					});
 				}
 			});

--- a/app/src/components/singleHistogram/tooltip.vue
+++ b/app/src/components/singleHistogram/tooltip.vue
@@ -68,7 +68,7 @@ export default {
 				})
 				.attrs({
 					"x": () => {
-						if (this.mousePosX + this.halfWidth > document.getElementById(this.parentID).clientWidth - 25) {
+						if (this.mousePosX + this.halfWidth > document.getElementById(this.parentID).clientWidth) {
 							return (this.mousePosX) - this.halfWidth + "px";
 						}
 						return (this.mousePosX) + "px";
@@ -88,7 +88,7 @@ export default {
 				.attrs({
 					"class": "toolTipContent",
 					"x": () => {
-						if (this.mousePosX + this.halfWidth > document.getElementById(this.parentID).clientWidth - 25) {
+						if (this.mousePosX + this.halfWidth > document.getElementById(this.parentID).clientWidth) {
 							return (this.mousePosX + this.offset) - this.halfWidth+ "px";
 						}
 						return (this.mousePosX) + this.offset + "px";

--- a/app/src/components/singleHistogram/tooltip.vue
+++ b/app/src/components/singleHistogram/tooltip.vue
@@ -63,13 +63,13 @@ export default {
 					"stroke": "black",
 					"rx": "10px",
 					"fill-opacity": 1,
-					"width": measure.width + 20,
+					"width": measure.width + 30,
 					"height": measure.height / 1.5 + this.offset,
 				})
 				.attrs({
 					"x": () => {
 						if (this.mousePosX + this.halfWidth > document.getElementById(this.parentID).clientWidth - 25) {
-							return (this.mousePosX) + "px";
+							return (this.mousePosX) - this.halfWidth + "px";
 						}
 						return (this.mousePosX) + "px";
 
@@ -89,7 +89,7 @@ export default {
 					"class": "toolTipContent",
 					"x": () => {
 						if (this.mousePosX + this.halfWidth > document.getElementById(this.parentID).clientWidth - 25) {
-							return (this.mousePosX + this.offset) + "px";
+							return (this.mousePosX + this.offset) - this.halfWidth+ "px";
 						}
 						return (this.mousePosX) + this.offset + "px";
 

--- a/app/src/components/singleHistogram/tooltip.vue
+++ b/app/src/components/singleHistogram/tooltip.vue
@@ -64,7 +64,7 @@ export default {
 					"rx": "10px",
 					"fill-opacity": 1,
 					"width": measure.width + 30,
-					"height": measure.height / 1.5 + this.offset,
+					"height": measure.height / 1.5 + this.offset / 1.5,
 				})
 				.attrs({
 					"x": () => {

--- a/app/src/components/singleScatterplot/index_ss.vue
+++ b/app/src/components/singleScatterplot/index_ss.vue
@@ -319,17 +319,21 @@ export default {
 				.style("stroke", "#202020")
 				.style("stroke-width", 0.5)
 				.on("mouseover", function (d, i) {
-					d3.select(this).style("fill", "orange");
 					d3.selectAll(".dot")
 						.style("fill", self.generalColors.intermediate)
-						.style("fill-opacity", 0.5);	
-					const text = "rank " + d.rank;
+						.style("stroke", self.generalColors.intermediate)
+						.style("fill-opacity", 0.1);	
+					d3.select(this)
+						.style("fill", "orange")
+						.style("stroke", "#202020")
+						.style("fill-opacity", 1);
+					const text = "MPI rank: " + d.rank;
 					self.$refs.ToolTip.render(text, d);
 				})
 				.on("mouseout", function (d, i) {
-					d3.select(this).attr("fill", self.generalColors.intermediate);
 					d3.selectAll(".dot")
 						.style("fill", self.generalColors.intermediate)
+						.style("stroke", "#202020")
 						.style("fill-opacity", 1);
 					self.$refs.ToolTip.clear();
 				});

--- a/app/src/lib/utils.js
+++ b/app/src/lib/utils.js
@@ -151,16 +151,6 @@ export function addIndexToBeginning(arr) {
 }
 
 export function truncNames(str, len) {
-	if (str.indexOf("=")) {
-		str = str.split("=")[0];
-	}
-
-	if (str.indexOf(":") > -1) {
-		let str_list = str.split(":");
-		str = str_list[str_list.length - 1];
-	}
-
-	str = str.replace(/<unknown procedure>/g, "proc ");
 	return (str.length > len) ? str.substr(0, len - 1) + "..." : str;
 }
 

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -340,7 +340,7 @@ export default new Vuex.Store({
 
 		updateDistributionColorMap({ state, dispatch }, payload) {
 			state.distributionColorMap = payload;
-			dispatch("reset");
+			EventHandler.$emit("update-ensemble-colors");
 		},
 
 		updateSelectedColorPoint({ state, dispatch }, payload) {

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -37,10 +37,14 @@ export default new Vuex.Store({
 
 		// Color
 		targetColorMap: {
-			Green: "#4EAF4A",
-			Blue: "#4681B4",
+			Green: "#4DAF4A",
+			Blue: "#3366CC",
 			Brown: "#AF9B90",
 			Red: "#A90400",
+			Vermillion: "#dc3912",
+			Yellow: "#ff9900",
+			Majenta: "#990099",
+			Pink: "#dd4477"
 		},
 		generalColors: {
 			silver: "#c0c0c0",
@@ -219,7 +223,11 @@ export default new Vuex.Store({
 
 		setIQRFactor(state, payload) {
 			state.IQRFactor = payload;
-		}
+		},
+
+		setTargetColor(state, payload) {
+			state.targetColor = payload;
+		},
 	},
 	
 	actions: {
@@ -383,13 +391,19 @@ export default new Vuex.Store({
 
 		updateIQRFactor({state, commit}, payload) {
 			commit("setIQRFactor", payload);
-			console.log("[Interaction] Updating IQR Factor.");
+			console.log("[Interaction] Updating IQR Factor: ", payload);
 			if (state.selectedMode == "SG") {
 				EventHandler.$emit("reset-single-boxplots");
 			}
 			else if(state.selectedMode == "ESG") {
 				EventHandler.$emit("reset-ensemble-boxplots");
 			}
+		},
+
+		updateTargetColor({commit, dispatch}, payload) {
+			console.log("[Interaction] Updating Target color: ", payload);
+			commit("setTargetColor", payload);
+			dispatch("reset");
 		},
 
 		reset({state}) {

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -345,7 +345,7 @@ export default new Vuex.Store({
 
 		updateDistributionColorMap({ state, dispatch }, payload) {
 			state.distributionColorMap = payload;
-			EventHandler.$emit("update-ensemble-colors");
+			EventHandler.$emit("update-node-encoding");
 		},
 
 		updateSelectedColorPoint({ state, dispatch }, payload) {

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -98,6 +98,7 @@ export default new Vuex.Store({
 		compareData: {},
 
 		encoding: "MEAN",
+		IQRFactor: 1.5,
 	},
 
 	mutations: {
@@ -214,6 +215,10 @@ export default new Vuex.Store({
 		
 		setCompareData(state, payload) {
 			state.compareData = payload;
+		},
+
+		setIQRFactor(state, payload) {
+			state.IQRFactor = payload;
 		}
 	},
 	
@@ -374,6 +379,17 @@ export default new Vuex.Store({
 
 		updateNodeEncoding() {
 			EventHandler.$emit("update-node-encoding");
+		},
+
+		updateIQRFactor({state, commit}, payload) {
+			commit("setIQRFactor", payload);
+			console.log("[Interaction] Updating IQR Factor.");
+			if (state.selectedMode == "SG") {
+				EventHandler.$emit("reset-single-boxplots");
+			}
+			else if(state.selectedMode == "ESG") {
+				EventHandler.$emit("reset-ensemble-boxplots");
+			}
 		},
 
 		reset({state}) {

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -368,7 +368,8 @@ export default new Vuex.Store({
 
 		updateRunBinCount({ state, dispatch }, payload) {
 			state.runBinCount = payload;
-			EventHandler.$emit("reset-ensemble-histogram");
+			// EventHandler.$emit("reset-ensemble-histogram");
+			dispatch("reset");
 		},
 
 		updateRuntimeSortBy({ state, dispatch }, payload) {

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -259,73 +259,73 @@ export default new Vuex.Store({
 			commit("setTimeline", timeline);
 		},
 
-		async fetchSingleHistogram({ commit, state }, payload) {
+		async fetchSingleHistogram({ commit }, payload) {
 			const hist = await APIService.POSTRequest("single_histogram", payload);
 			console.log("[Data] Single Histogram: ", hist);
 			commit("setSingleHistogram", hist);
 		},
 		
-		async fetchSingleScatterplot({ commit, state }, payload) {
+		async fetchSingleScatterplot({ commit }, payload) {
 			const scat = await APIService.POSTRequest("single_scatterplot", payload);
 			console.log("[Data] Single Scatterplot: ", scat);
 			commit("setSingleScatterplot", scat["tgt"]);
 		},
 
-		async fetchSingleBoxplots({ commit, state }, payload) {
+		async fetchSingleBoxplots({ commit }, payload) {
 			const bps = await APIService.POSTRequest("single_boxplots", payload);
 			console.log("[Data] Single boxplots: ", bps);
 			commit("setSingleBoxplots", bps);
 		},
 
-		async fetchCCT({ commit, state }, payload) {
+		async fetchCCT({ commit }, payload) {
 			const cct = await APIService.POSTRequest("cct", payload);
 			console.log("[Data] CCT for", payload.dataset, "is :", cct);
 			commit("setCCT", cct);
 		},
 
-		async fetchSG({ commit, state }, payload) {
+		async fetchSG({ commit }, payload) {
 			const sg = await APIService.POSTRequest("single_supergraph", payload);
 			console.log("[Data] SG: ", sg);
 			commit("setSG", sg);
 		},
 
-		async fetchESG({ commit, state }, payload) {
+		async fetchESG({ commit }, payload) {
 			const esg = await APIService.POSTRequest("ensemble_supergraph", payload);
 			console.log("[Data] ESG: ", esg);
 			commit("setESG", esg);
 		},
 
-		async fetchEnsembleHistogram({ commit, state }, payload) {
+		async fetchEnsembleHistogram({ commit }, payload) {
 			const esh = await APIService.POSTRequest("ensemble_histogram", payload);
 			console.log("[Data] ESG Histogram: ", esh);
 			commit("setEnsembleHistogram", esh);
 		},
 		
-		async fetchEnsembleScatterplot({ commit, state }, payload) {
+		async fetchEnsembleScatterplot({ commit }, payload) {
 			const ess = await APIService.POSTRequest("ensemble_scatterplot", payload);
 			console.log("[Data] ESG Scatterplot: ", ess);
 			commit("setEnsembleScatterplot", ess);
 		},
 
-		async fetchEnsembleBoxplots({ commit, state }, payload) {
+		async fetchEnsembleBoxplots({ commit }, payload) {
 			const esb = await APIService.POSTRequest("ensemble_boxplots", payload);
 			console.log("[Data] ESG Boxplots: ", esb);
 			commit("setEnsembleBoxplots", esb);
 		},
 
-		async fetchParameterProjection({ commit, state }, payload) {
+		async fetchParameterProjection({ commit }, payload) {
 			const pp = await APIService.POSTRequest("projection", payload);
 			console.log("[Data] ESG Projection: ", JSON.parse(pp));
 			commit("setParameterProjection", JSON.parse(pp));
 		},
 
-		async fetchGradients({ commit, state }, payload) {
+		async fetchGradients({ commit }, payload) {
 			const grad = await APIService.POSTRequest("gradients", payload);
 			console.log("[Data] ESG Gradients: ", grad);
 			commit("setParameterProjection", grad);
 		},
 
-		async fetchHierarchy({ commit, state }, payload) {
+		async fetchHierarchy({ commit }, payload) {
 			const hierarchy = await APIService.POSTRequest("module_hierarchy", payload);
 			console.log("[Data] ESG Hierarchy: ", hierarchy);
 			commit("setHierarchy", hierarchy);
@@ -351,7 +351,7 @@ export default new Vuex.Store({
 			dispatch("reset");
 		},
 
-		updateDistributionColorMap({ state, dispatch }, payload) {
+		updateDistributionColorMap({ state }, payload) {
 			state.distributionColorMap = payload;
 			EventHandler.$emit("update-node-encoding");
 		},
@@ -361,14 +361,13 @@ export default new Vuex.Store({
 			dispatch("reset");
 		},
 
-		updateRankBinCount({ state, dispatch }, payload) {
+		updateRankBinCount({ state }, payload) {
 			state.rankBinCount = payload;
 			EventHandler.$emit("reset-single-histogram");
 		},
 
 		updateRunBinCount({ state, dispatch }, payload) {
 			state.runBinCount = payload;
-			// EventHandler.$emit("reset-ensemble-histogram");
 			dispatch("reset");
 		},
 
@@ -381,9 +380,10 @@ export default new Vuex.Store({
 			}
 		},
 
-		updateCompareRun({ state, dispatch}, payload) {
-			state.commit("setCompareRun", payload);
-			state.commit("setIsComparisonMode", payload);
+		updateCompareRun({ commit }, payload) {
+			commit("setCompareRun", payload);
+			commit("setComparisonMode", payload);
+			EventHandler.$emit("update-ensemble-colors");
 		},
 
 		updateNodeEncoding() {

--- a/callflow/modules/histogram.py
+++ b/callflow/modules/histogram.py
@@ -95,6 +95,7 @@ class Histogram:
                 'abs': dhist[1],
                 'rel': rhist[1],
                 'rng': dhist[0],
+                'dig': dhist[2],
             }
 
             if node_type == "callsite":
@@ -124,6 +125,7 @@ class Histogram:
                     "x_max": float(data[histo_type]['rng'][-1]),
                     "y_min": float(data[histo_type]['abs'].min()),
                     "y_max": float(data[histo_type]['abs'].max()),
+                    "dig": Histogram._get_digs_as_dict_array(data[histo_type]['dig']),
                 }
                 if 'rel' in data[histo_type].keys() and data[histo_type]["rel"] is not None:
                     result[metric][histo_type]["rel_y"] = data[histo_type]['rel'].tolist()
@@ -133,6 +135,16 @@ class Histogram:
                 result[metric]["d"] = data["d"].tolist()
         
         return result
+
+    def _get_digs_as_dict_array(arr):
+        ret = {}
+        for x in zip(iter(arr), range(0, len(arr))):
+            bin_idx = int(x[0]) - 1
+            if bin_idx not in ret:
+                ret[bin_idx] = []
+                
+            ret[bin_idx].append(int(x[1]))
+        return ret
 
     # --------------------------------------------------------------------------
     def _get_data_by_histo_type(self, df, histo_type):
@@ -171,6 +183,6 @@ class Histogram:
         :param histo:
         :return:
         """
-        return {"b": histo[0], "h": histo[1]}
+        return {"b": histo[0], "h": histo[1], "dig": histo[2]}
 
 # ------------------------------------------------------------------------------

--- a/callflow/utils/utils.py
+++ b/callflow/utils/utils.py
@@ -95,7 +95,9 @@ def histogram(data, data_range=None, bins=20):
         assert isinstance(data_range, (list, np.ndarray))
         assert len(data_range) == 2
     h, b = np.histogram(data, range=data_range, bins=bins)
-    return 0.5 * (b[1:] + b[:-1]), h
+    dig = np.digitize(data, b)
+
+    return 0.5 * (b[1:] + b[:-1]), h, dig
 
 
 def freedman_diaconis_bins(arr):

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -527,11 +527,12 @@ class BaseProvider:
             return scatterplot.unpack()
         
         elif operation_name == "boxplots":
-            callsites = operation["callsites"]
+            callsites = operation.get("callsites", [])
+            iqr = float(operation.get("iqr", 1.5))
 
             result = {}
             for callsite in callsites:
-                bp = BoxPlot(sg=sg, relative_sg=e_sg, name=callsite, ntype=ntype, proxy_columns=t_sg.proxy_columns)
+                bp = BoxPlot(sg=sg, relative_sg=e_sg, name=callsite, ntype=ntype, iqr_scale=iqr, proxy_columns=t_sg.proxy_columns)
                 result[callsite] = bp.unpack()
             
             return result

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -474,7 +474,7 @@ class BaseProvider:
                 grp_column="group_path",    
                 sg=sg,
                 esg=e_sg,
-                nbins=operation.get("nbins", 20),
+                nbins=int(operation.get("nbins", 20)),
                 reveal_callsites=operation.get("reveal_callsites", []),
                 split_entry_module=operation.get("split_entry_module", []),
                 split_callee_module= operation.get("split_callee_module", []),
@@ -482,7 +482,8 @@ class BaseProvider:
             return ssg.nxg
 
         elif operation_name == "module_hierarchy":
-            hl = HierarchyLayout(esg=e_sg, node=operation.get("node"), nbins=operation.get("nbins", 20))
+            nbins = int(operation.get("nbins", 20))
+            hl = HierarchyLayout(esg=e_sg, node=operation.get("node"), nbins=nbins)
             return hl.nxg
 
         elif operation_name == "projection":
@@ -506,11 +507,12 @@ class BaseProvider:
 
         elif operation_name == "histogram":
             node = operation["node"]
-            nbins = operation["nbins"]
+            nbins = int(operation.get("nbins", 20))
 
             hist = Histogram(dataframe=t_aux_dict[node], relative_to_df=e_aux_dict[node],
                         histo_types=["rank"],
                         node_type=ntype,
+                        bins=nbins,
                         proxy_columns=t_sg.proxy_columns)
 
             return hist.unpack()


### PR DESCRIPTION
This PR includes the following fixes to improve stability when the user interacts between the modes and adds some more assorted features. 

* Add IQR Factor, distribution colormap, and target color selection in the settings.
* Reduce the height of the individual views on the left.
* Enable tooltips for the ESG histogram and scatterplot views
* Replace this.generalColors.target => this.targetColor.
* Fix tooltip and ranklines for SG histogram.
* Add colormap for ESG
* Module hierarchy updates on color changes. 
* Cleaning of ensemble gradients. 
* Move rankling processing to the server. 
* IQR changes in the server (using np.digitize).
