### PR TITLE
Consistent callsite-module mapping while loading, processing in different modes.

### DIFF
--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -41,6 +41,7 @@ from callflow.utils.df import (
 )
 from .metrics import FILE_FORMATS, METRIC_PROXIES, TIME_COLUMNS
 from callflow.modules import Histogram
+from callflow.utils.utils import get_file_size
 
 LOGGER = get_logger(__name__)
 
@@ -1235,6 +1236,19 @@ class SuperGraph(ht.GraphFrame):
             fptr.write(graph_str)
 
     @staticmethod
+    def write_module_callsite_maps(path, data):
+        """
+        Write the callsite-idx, module-idx, callsite-module mappings into a
+        pickle file.
+
+        :param path: Path to where the maps should be written.
+        """
+        fname = os.path.join(path, SuperGraph._FILENAMES["maps"])
+        LOGGER.debug(f"Writing ({fname})")
+        with open(fname, 'w') as handle:
+            json.dump(data, handle)
+
+    @staticmethod
     def read_df(path):
         """
 
@@ -1242,7 +1256,7 @@ class SuperGraph(ht.GraphFrame):
         :return:
         """
         fname = os.path.join(path, SuperGraph._FILENAMES["df"])
-        LOGGER.debug(f"Reading ({fname})")
+        LOGGER.debug(f"Reading ({fname}) [{get_file_size(fname)}]")
 
         df = None
         ext = os.path.splitext(SuperGraph._FILENAMES["df"])[-1]
@@ -1263,7 +1277,7 @@ class SuperGraph(ht.GraphFrame):
         :return:
         """
         fname = os.path.join(path, SuperGraph._FILENAMES["nxg"])
-        LOGGER.debug(f"Reading ({fname})")
+        LOGGER.debug(f"Reading ({fname}) [{get_file_size(fname)}]")
         with open(fname, "r") as nxg_file:
             graph = json.load(nxg_file)
             nxg = nx.readwrite.json_graph.node_link_graph(graph)
@@ -1279,7 +1293,7 @@ class SuperGraph(ht.GraphFrame):
         :return:
         """
         fname = os.path.join(path, SuperGraph._FILENAMES["ht"])
-        LOGGER.debug(f"Reading ({fname})")
+        LOGGER.debug(f"Reading ({fname}) [{get_file_size(fname)}]")
         with open(fname, "r") as graph_file:
             graph = json.load(graph_file)
         if not isinstance(graph, ht.GraphFrame.Graph):
@@ -1296,7 +1310,7 @@ class SuperGraph(ht.GraphFrame):
         data = {}
         try:
             fname = os.path.join(path, SuperGraph._FILENAMES["params"])
-            LOGGER.debug(f"Reading ({fname})")
+            LOGGER.debug(f"Reading ({fname}) [{get_file_size(fname)}]")
             for line in open(fname, "r"):
                 for num in line.strip().split(","):
                     split_num = num.split("=")
@@ -1306,22 +1320,9 @@ class SuperGraph(ht.GraphFrame):
         return data
 
     @staticmethod
-    def write_module_callsite_maps(path, data):
-        """
-        Write the callsite-idx, module-idx, callsite-module mappings into a
-        pickle file.
-
-        :param path: Path to where the maps should be written.
-        """
-        fname = os.path.join(path, SuperGraph._FILENAMES["maps"])
-        LOGGER.debug(f"Writing ({fname})")
-        with open(fname, 'w') as handle:
-            json.dump(data, handle)
-
-    @staticmethod
     def read_module_callsite_maps(path):        
         fname = os.path.join(path, SuperGraph._FILENAMES["maps"])
-        LOGGER.debug(f"Reading ({fname})")
+        LOGGER.debug(f"Reading ({fname}) [{get_file_size(fname)}]")
         with open(fname, 'r') as f:
             data = json.load(f)
 

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -1028,8 +1028,9 @@ class SuperGraph(ht.GraphFrame):
         mean_runtime = 0.0
         column = self.df_get_proxy(column)
         for root in roots:
+            root_idx = self.get_idx(root, "callsite")
             mean_runtime = max(
-                mean_runtime, self.df_lookup_with_column("name", root)[column].mean()
+                mean_runtime, self.df_lookup_with_column("name", root_idx)[column].mean()
             )
         return round(mean_runtime, 2)
 

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -616,8 +616,6 @@ class SuperGraph(ht.GraphFrame):
             self.module2callsite = {m: [m] for m in range(len(self.modules))}
 
         # ----------------------------------------------------------------------
-        # self.inv_callsites = {v: i for i, v in self.callsites.items()}
-        # self.inv_modules = {v: i for i, v in self.modules.items()}
 
         self.callsites_list = np.array(list(self.callsite2module.keys()))
         self.modules_list = np.array(list(self.module2callsite.keys()))
@@ -651,9 +649,12 @@ class SuperGraph(ht.GraphFrame):
         self.df_add_column("name", apply_dict=self.callsite2idx,
                            apply_on="name", update=True)
 
+        self.callsites_idx = self.dataframe["name"].unique().tolist()
+
         LOGGER.debug(f"Factorizing modules")
         self.df_add_column("module", apply_dict=self.module2idx,
                            apply_on="module", update=True)
+        self.modules_idx = self.dataframe["module"].unique().tolist()
 
     # --------------------------------------------------------------------------
     def add_time_proxies(self):

--- a/callflow/datastructures/supergraph.py
+++ b/callflow/datastructures/supergraph.py
@@ -110,7 +110,7 @@ class SuperGraph(ht.GraphFrame):
     def __str__(self):
         """SuperGraph string representation"""
         return (
-            f"SuperGraph<{self.name}"
+            f"SuperGraph<{self.name}>"
             f"df = {self.dataframe.shape}, cols = {list(self.dataframe.columns)}>"
         )
 
@@ -433,14 +433,17 @@ class SuperGraph(ht.GraphFrame):
 
         if read_maps:
             maps = SuperGraph.read_module_callsite_maps(path)
-            self.new_module2idx = maps["m2idx"]
-            self.new_callsite2idx = maps["c2idx"]
-            self.new_module2callsite = maps["m2c"]
+            self.module2idx = maps["m2idx"]
+            self.callsite2idx = maps["c2idx"]
+            self.module2callsite = maps["m2c"]
 
         # Calculate inverse mappings
-        self.new_idx2module = {v: k for k, v in self.new_module2idx.items()}
-        self.new_idx2callsite = {v: k for k, v in self.new_callsite2idx.items()}
-        # self.new_callsite2module = {v: k for k, v in self.new_callsite2module.items()}
+        self.idx2module = {v: k for k, v in self.module2idx.items()}
+        self.idx2callsite = {v: k for k, v in self.callsite2idx.items()}
+        
+        self.modules = list(module_callsite_map.keys());
+        # for m in self.module2callsite.keys():
+        #     print(m)
 
         # print('--- new_idx2module:', self.new_idx2module, self.new_module2idx)
 
@@ -534,7 +537,7 @@ class SuperGraph(ht.GraphFrame):
         self.idx2callsite, self.callsite2idx = self.df_factorize_column('name')
 
         # create a list of unique callsite names
-        self.callsites = np.sort(self.dataframe['name'].unique())
+        self.callsites = self.dataframe['name'].unique().tolist()
 
         ncallsites = len(self.callsites)
         LOGGER.debug(f'Found {ncallsites} callsites: {list(self.callsites)}')
@@ -544,7 +547,8 @@ class SuperGraph(ht.GraphFrame):
         # ----------------------------------------------------------------------
         if has_modules_in_map:
             LOGGER.debug(f"[{self.name}] Using the supplied module map")
-            self.modules = module_callsite_map.keys()
+            self.modules = np.array(list(module_callsite_map.keys()))
+
 
             self.idx2module = {i: m for i, m in enumerate(self.modules)}
             self.module2idx = dict((v, k) for k, v in self.idx2module.items())
@@ -604,12 +608,12 @@ class SuperGraph(ht.GraphFrame):
                 f'[{self.name}] No module map found. Defaulting to "module=callsite"'
             )
 
-            self.new_modules = np.copy(self.new_callsites)
-            self.new_module2idx = {m: midx for midx, m in enumerate(self.new_modules)}
+            self.modules = np.copy(self.callsites)
+            self.module2idx = {m: midx for midx, m in enumerate(self.modules)}
             self.df_add_column("module", apply_func=lambda _: _, apply_on="name")
 
-            self.new_callsite2module = {c: c for c in range(len(self.new_callsites))}
-            self.new_module2callsite = {m: [m] for m in range(len(self.new_modules))}
+            self.callsite2module = {c: c for c in range(len(self.callsites))}
+            self.module2callsite = {m: [m] for m in range(len(self.modules))}
 
         # ----------------------------------------------------------------------
         # self.inv_callsites = {v: i for i, v in self.callsites.items()}

--- a/callflow/layout/hierarchy.py
+++ b/callflow/layout/hierarchy.py
@@ -20,7 +20,7 @@ class HierarchyLayout:
     Hierarchy Layout computation
     """
 
-    def __init__(self, sg, esg, dataset, node, nbins):
+    def __init__(self, esg, dataset, node, nbins):
         """
         Hierarchy Layout computation
 
@@ -32,11 +32,10 @@ class HierarchyLayout:
         assert node in list(esg.modules_list)
 
         self.node = node
-        module_idx = sg.get_idx(node, "module")
+        module_idx = esg.get_idx(node, "module")
 
-        self.sg = sg
         self.esg = esg
-        module_df = sg.dataframe.loc[sg.dataframe["module"] == module_idx]
+        module_df = esg.dataframe.loc[esg.dataframe["module"] == module_idx]
 
         self.time_exc = self.esg.df_get_proxy("time")
         self.time_inc = self.esg.df_get_proxy("time (inc)")
@@ -105,9 +104,9 @@ class HierarchyLayout:
 
     def esg_node_construct(self, nid, ntype, name, nbins):
         if ntype == "callsite":
-            time_inc = self.esg.get_runtime(name, ntype, self.time_inc)
-            time_exc = self.esg.get_runtime(name, ntype, self.time_exc)
-            grads = self.esg.get_gradients(name, ntype, nbins)
+            time_inc = self.esg.get_runtime(nid, ntype, self.time_inc)
+            time_exc = self.esg.get_runtime(nid, ntype, self.time_exc)
+            grads = self.esg.get_gradients(nid, ntype, nbins)
         elif ntype == "module":
             time_inc = self.esg.get_runtime(nid, ntype, self.time_inc)
             time_exc = self.esg.get_runtime(nid, ntype, self.time_exc)

--- a/callflow/layout/node_link.py
+++ b/callflow/layout/node_link.py
@@ -66,7 +66,7 @@ class NodeLinkLayout:
                     datamap[column] = {}
 
                 callsite_idx = self.sg.get_idx(callsite, "callsite")
-                _df = self.sg.df_lookup_with_column("name", callsite)
+                _df = self.sg.df_lookup_with_column("name", callsite_idx)
 
                 if column == self.time_inc:
                     datamap[column][callsite] = _df["time (inc)"].mean()

--- a/callflow/modules/boxplot.py
+++ b/callflow/modules/boxplot.py
@@ -48,15 +48,15 @@ class BoxPlot:
         if relative_sg is not None:
             self.box_types = ["tgt", "bkg"]
 
-        self.nid = sg.get_idx(name, ntype)
-        node = {"id": self.nid, "type": ntype, "name": name}
+        self.idx = sg.get_idx(name, ntype)
+        node = {"id": self.idx, "type": ntype, "name": name}
 
         # TODO: Avoid this.
         self.c_path = None
         self.rel_c_path = None
 
         if ntype == "callsite":
-            df = sg.callsite_aux_dict[name]
+            df = sg.callsite_aux_dict[self.idx]
             if "component_path" in sg.dataframe.columns:
                 self.c_path = sg.get_component_path(node)
 
@@ -67,9 +67,9 @@ class BoxPlot:
                     self.rel_c_path = sg.get_component_path(node)
 
         elif ntype == "module":
-            df = sg.module_aux_dict[self.nid]
+            df = sg.module_aux_dict[self.idx]
             if relative_sg is not None:
-                rel_df = relative_sg.module_aux_dict[self.nid]
+                rel_df = relative_sg.module_aux_dict[self.idx]
 
         if relative_sg is not None and "dataset" in rel_df.columns:
             self.ndataset = df_count(rel_df, "dataset")
@@ -122,7 +122,7 @@ class BoxPlot:
                 "uv": (_mean, _var),
                 "imb": _imb,
                 "ks": (_kurt, _skew),
-                "nid": self.nid,
+                "idx": self.idx,
             }
             if "dataset" in df.columns:
                 ret[tk]["odset"] = df["dataset"].to_numpy()[mask]
@@ -158,7 +158,7 @@ class BoxPlot:
                     "imb": box["imb"],
                     "kurt": box["ks"][0],
                     "skew": box["ks"][1],
-                    "nid": box["nid"],
+                    "nid": box["idx"],
                     "name": self.result["name"],
                 }
                 result["name"] = self.result["name"]

--- a/callflow/modules/boxplot.py
+++ b/callflow/modules/boxplot.py
@@ -61,7 +61,7 @@ class BoxPlot:
                 self.c_path = sg.get_component_path(node)
 
             if relative_sg is not None:
-                rel_df = relative_sg.callsite_aux_dict[name]
+                rel_df = relative_sg.callsite_aux_dict[self.idx]
 
                 if "component_path" in relative_sg.dataframe.columns:
                     self.rel_c_path = sg.get_component_path(node)

--- a/callflow/operations/filter.py
+++ b/callflow/operations/filter.py
@@ -46,6 +46,7 @@ class Filter:
         )
 
         self.callsites = self.sg.callsites
+        #self.callsites = self.sg.new_callsites
 
         # if 0:
         self.mean_root_inctime = self.sg.df_root_max_mean_runtime(
@@ -69,6 +70,7 @@ class Filter:
 
         LOGGER.debug(f"Number of callsites after QueryMatcher: {len(self.callsites)}")
         LOGGER.info(
+            #f"Removed {len(self.sg.new_callsites) - len(self.callsites)} callsites."
             f"Removed {len(self.sg.callsites) - len(self.callsites)} callsites."
         )
 

--- a/callflow/operations/filter.py
+++ b/callflow/operations/filter.py
@@ -45,8 +45,9 @@ class Filter:
             f'Filtering ({self.sg}) by "{self.filter_by}" = {self.filter_perc}%'
         )
 
-        self.callsites = self.sg.callsites
-        #self.callsites = self.sg.new_callsites
+        # TODO: Since we factorize the name and module column after creating
+        # the CallFlow.dataframe, we need to filter by the callsite indexes. 
+        self.callsites = self.sg.callsites_idx
 
         # if 0:
         self.mean_root_inctime = self.sg.df_root_max_mean_runtime(
@@ -66,12 +67,11 @@ class Filter:
         LOGGER.info(f"Filtering GraphFrame by Hatchet Query :{query}")
         LOGGER.debug(f"Number of callsites before QueryMatcher: {len(self.callsites)}")
 
-        filtered_callsites = self.sg.hatchet_filter_callsites_by_query(query)
+        self.callsites = self.sg.hatchet_filter_callsites_by_query(query)
 
-        LOGGER.debug(f"Number of callsites after QueryMatcher: {len(filtered_callsites)}")
+        LOGGER.debug(f"Number of callsites after QueryMatcher: {len(self.callsites)}")
         LOGGER.info(
-            f"Removed {len(self.sg.callsites) - len(filtered_callsites)} callsites."
-            # f"Removed {len(self.sg.callsites) - len(self.callsites)} callsites."
+            f"Removed {len(self.sg.callsites) - len(self.callsites)} callsites."
         )
 
         # LOGGER.debug(f"Callsites: {','.join(self.callsites[:50]) }")
@@ -119,8 +119,10 @@ class Filter:
 
         if filter_by == "time (inc)":
             for edge in self.sg.nxg.edges():
+                edge0_idx = self.sg.get_idx(edge[0], 'callsite')
+                edge1_idx = self.sg.get_idx(edge[1], 'callsite')
                 # If source is present in the callsites list
-                if (edge[0] in self.callsites) and (edge[1] in self.callsites):
+                if (edge0_idx in self.callsites) and (edge1_idx in self.callsites):
                     nxg.add_edge(edge[0], edge[1])
                 # else:
                 #    LOGGER.debug(f"Removing the edge: {edge}")

--- a/callflow/operations/filter.py
+++ b/callflow/operations/filter.py
@@ -71,7 +71,7 @@ class Filter:
 
         LOGGER.debug(f"Number of callsites after QueryMatcher: {len(self.callsites)}")
         LOGGER.info(
-            f"Removed {len(self.sg.callsites) - len(self.callsites)} callsites."
+            f"Removed {len(self.sg.callsites_idx) - len(self.callsites)} callsites."
         )
 
         # LOGGER.debug(f"Callsites: {','.join(self.callsites[:50]) }")

--- a/callflow/operations/filter.py
+++ b/callflow/operations/filter.py
@@ -66,15 +66,15 @@ class Filter:
         LOGGER.info(f"Filtering GraphFrame by Hatchet Query :{query}")
         LOGGER.debug(f"Number of callsites before QueryMatcher: {len(self.callsites)}")
 
-        self.callsites = self.sg.hatchet_filter_callsites_by_query(query)
+        filtered_callsites = self.sg.hatchet_filter_callsites_by_query(query)
 
-        LOGGER.debug(f"Number of callsites after QueryMatcher: {len(self.callsites)}")
+        LOGGER.debug(f"Number of callsites after QueryMatcher: {len(filtered_callsites)}")
         LOGGER.info(
-            #f"Removed {len(self.sg.new_callsites) - len(self.callsites)} callsites."
-            f"Removed {len(self.sg.callsites) - len(self.callsites)} callsites."
+            f"Removed {len(self.sg.callsites) - len(filtered_callsites)} callsites."
+            # f"Removed {len(self.sg.callsites) - len(self.callsites)} callsites."
         )
 
-        LOGGER.debug(f"Callsites: {','.join(self.callsites[:50]) }")
+        # LOGGER.debug(f"Callsites: {','.join(self.callsites[:50]) }")
 
         self.compute()
 
@@ -120,7 +120,7 @@ class Filter:
         if filter_by == "time (inc)":
             for edge in self.sg.nxg.edges():
                 # If source is present in the callsites list
-                if edge[0] in self.callsites and edge[1] in self.callsites:
+                if (edge[0] in self.callsites) and (edge[1] in self.callsites):
                     nxg.add_edge(edge[0], edge[1])
                 # else:
                 #    LOGGER.debug(f"Removing the edge: {edge}")

--- a/callflow/operations/group.py
+++ b/callflow/operations/group.py
@@ -78,6 +78,7 @@ class Group:
 
             if debug:
                 for _ in path:
+                    #_m = self.sg.new_callsite2module[_]
                     _m = self.sg.callsite_module_map[_]
                     print(
                         "\t:",
@@ -91,6 +92,7 @@ class Group:
                     )
 
             # extract the modules in the path
+            #mod_path = np.array([self.sg.new_callsite2module[_] for _ in path])
             mod_path = np.array([self.sg.callsite_module_map[_] for _ in path])
 
             if debug:

--- a/callflow/operations/group.py
+++ b/callflow/operations/group.py
@@ -196,10 +196,10 @@ class Group:
 
         # update the dataframe
         self.sg.df_add_column(
-            "group_path", apply_dict=group_path, dict_default="", apply_on="nid"
+            "group_path", apply_dict=group_path, dict_default="", apply_on="name"
         )
         self.sg.df_add_column(
-            "component_path", apply_dict=component_path, dict_default="", apply_on="nid"
+            "component_path", apply_dict=component_path, dict_default="", apply_on="name"
         )
         LOGGER.profile("Finished Grouping.")
 

--- a/callflow/operations/group.py
+++ b/callflow/operations/group.py
@@ -93,7 +93,7 @@ class Group:
 
             # extract the modules in the path
             #mod_path = np.array([self.sg.new_callsite2module[_] for _ in path])
-            mod_path = np.array([self.sg.callsite_module_map[_] for _ in path])
+            mod_path = np.array([self.sg.callsite2module[_] for _ in path])
 
             if debug:
                 print("path modules =", type(mod_path), mod_path.shape, mod_path)

--- a/callflow/operations/unify.py
+++ b/callflow/operations/unify.py
@@ -14,6 +14,7 @@ from functools import reduce
 import callflow
 from callflow.utils.utils import create_reindex_map
 
+
 LOGGER = callflow.get_logger(__name__)
 
 

--- a/callflow/operations/unify.py
+++ b/callflow/operations/unify.py
@@ -73,13 +73,13 @@ class Unify:
                 sg.df_add_column(
                     "module",
                     update=True,
-                    apply_func=lambda _: _mod_map[_],
+                    apply_func=lambda _: self.eg.modules_list[_mod_map[_]],
                     apply_on="module",
                 )
                 sg.df_add_column(
                     "name",
                     update=True,
-                    apply_func=lambda _: _cs_map[_],
+                    apply_func=lambda _: self.eg.callsites_list[_cs_map[_]],
                     apply_on="name",
                 )
 
@@ -152,6 +152,9 @@ class Unify:
             self.eg.nxg.add_edges_from(new_edges)
 
             # ------------------------------------------------------------------
+
+        self.eg.add_callsites_and_modules_maps()
+        self.eg.factorize_callsites_and_modules()
 
 
 # ------------------------------------------------------------------------------

--- a/callflow/utils/utils.py
+++ b/callflow/utils/utils.py
@@ -21,20 +21,26 @@ import psutil
 # ------------------------------------------------------------------------------
 
 
-def get_memory_usage(process=None):
+def get_memory_usage(process = None):
     if process is None:
         process = psutil.Process(os.getpid())
 
     bytes = float(process.memory_info().rss)
+    return format_bytes(bytes)
 
-    if bytes < 1024.0:
-        return f"{bytes} bytes"
+def format_bytes(bytes):
+    if bytes < 1024.:
+        return f'{bytes} bytes'
 
-    kb = bytes / 1024.0
-    if kb < 1024.0:
-        return f"{kb} KB"
+    kb = bytes / 1024.
+    if kb < 1024.:
+        return f'{kb} KB'
 
-    return f"{kb / 1024.} MB"
+    return f'{kb / 1024.} MB'
+
+def get_file_size(filepath):
+    stats = os.stat(filepath)
+    return format_bytes(stats.st_size)
 
 
 # ------------------------------------------------------------------------------

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -45,7 +45,7 @@ class BaseProvider:
         # ----------------------------------------------------------------------
         # Stage-1: Each dataset is processed individually into a SuperGraph.
         LOGGER.warning(
-            f'-------------------- TOTAL {len(self.config["runs"])} datasets detected from  in the CallFlow.config --------------------'
+            f'-------------------- TOTAL {len(self.config["runs"])} datasets detected from the CallFlow.config --------------------'
         )
         self.datasets = self.config["runs"]
 
@@ -350,8 +350,7 @@ class BaseProvider:
             if len(self.datasets) > 1:
                 sg = self.supergraphs["ensemble"]
             else:
-                sg = self.supergraphs[self.datasets[0].name]
-
+                sg = self.supergraphs[self.datasets[0]['name']]
             time_columns = sg.time_columns
 
             # if "module_callsite_map" not in self.config.keys():
@@ -383,14 +382,19 @@ class BaseProvider:
             assert isinstance(operation["ncount"], int)
             assert operation["metric"] in ["time", "time (inc)"]
 
+            if(len(self.supergraphs) == 1):
+                supergraph = self.supergraphs[self.datasets[0]['name']]
+            else:
+                supergraph = self.supergraphs["ensemble"]
+            
             # Get the top-n nodes from the "ensemble" based on the ntype.
-            top_nodes_idx = self.supergraphs["ensemble"].df_get_top_by_attr(
+            top_nodes_idx = supergraph.df_get_top_by_attr(
                 operation["ntype"], operation["ncount"], operation["metric"]
             )
 
             # Convert the indexs to the modules.
             top_nodes = [
-                self.supergraphs["ensemble"].get_name(node_idx, operation["ntype"])
+                supergraph.get_name(node_idx, operation["ntype"])
                 for node_idx in top_nodes_idx
             ]
             # Construct the per-supergraph timeline data.
@@ -603,7 +607,6 @@ class BaseProvider:
             nbins = int(operation.get("nbins", 20))
             dataset = operation.get("dataset")
             hl = HierarchyLayout(
-                sg=sg,
                 esg=e_sg,
                 dataset=dataset,
                 node=operation.get("node"),

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -248,9 +248,9 @@ class BaseProvider:
             Filter(sg, filter_by=filter_by, filter_perc=filter_perc)
             LOGGER.profile(f"Filtered supergraph {name}")
             #print('after filter:', sg.dataframe['module'])
-
+            
             sg.write(os.path.join(save_path, name))
-            #print('after write:', sg.dataframe['module'])
+            # print('after write:', sg.dataframe['module'])
             #exit()
 
             LOGGER.profile(f"Stored in dictionary {name}")
@@ -313,7 +313,7 @@ class BaseProvider:
         else:
             process_datasets, load_datasets = self.split_process_load_datasets()
 
-        if len(process_datasets) == 0:
+        if len(process_datasets) == 0 and not ensemble_process:
             LOGGER.warning("All datasets have been processed already. To re-process once again, use --reset. To process an ensemble of datasets, use --ensemble_process.")
             return 
             

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -234,9 +234,7 @@ class BaseProvider:
             sg.create(
                 path=data_path,
                 profile_format=_prop[1],
-                module_callsite_map=module_callsite_map,
-                filter_by=filter_by,
-                filter_perc=filter_perc,
+                module_callsite_map=module_callsite_map
             )
             #print('outside create:', sg.dataframe['module'])
 

--- a/server/provider_base.py
+++ b/server/provider_base.py
@@ -130,8 +130,8 @@ class BaseProvider:
             module_callsite_map=self.config.get("module_callsite_map", {}),
             read_parameter=read_param,
         )
-        if 'module' in sg.dataframe:
-            print ('after load:', sg.dataframe['module'])
+        # if 'module' in sg.dataframe:
+        #     print ('after load:', sg.dataframe['module'])
         return sg
 
     def split_process_load_datasets(self):
@@ -313,10 +313,10 @@ class BaseProvider:
         else:
             process_datasets, load_datasets = self.split_process_load_datasets()
 
-        if len(process_datasets) == 0 and not ensemble_process:
-            LOGGER.warning("All datasets have been processed already. To re-process once again, use --reset. To re-process only the ensemble, use --ensemble_process.")
- 
-
+        if len(process_datasets) == 0:
+            LOGGER.warning("All datasets have been processed already. To re-process once again, use --reset. To process an ensemble of datasets, use --ensemble_process.")
+            return 
+            
         LOGGER.warning(
             f"-------------------- PROCESSING {len(process_datasets)} SUPERGRAPHS --------------------"
         )
@@ -329,11 +329,11 @@ class BaseProvider:
             self.load_single(load_datasets)
 
 
-        if ensemble_process:
-            LOGGER.warning(
-                "-------------------- PROCESSING ENSEMBLE SUPERGRAPH --------------------"
-            )
-            self.process_ensemble(save_path)
+            if ensemble_process:
+                LOGGER.warning(
+                    "-------------------- PROCESSING ENSEMBLE SUPERGRAPH --------------------"
+                )
+                self.process_ensemble(save_path)
 
     def request_general(self, operation):
         """


### PR DESCRIPTION
This PR fixes the ambiguity of the dataframe columns ("module" and "name") when processing and loading in different formats.  To resolve this, the following changes have been done. 

- [x] `callsite2idx`, `idx2callsite`, `module2idx`, `idx2module`, `callsite2module` and `module2callsite` mappings are populated to keep track of the module, callsite structure.
- [x] `add_callsite_module_maps` will create the corresponding mappings.
- [x] `factorize_callsites_and_modules` will update the dataframe columns with the updated call site and module index mappings.  
- [x] These mappings are stored as JSON files (`maps.json`) in the `.callflow` directory.  
- [x]  Rewire the ensemble dataframe columns with the updated callsite and module indexes.
- [x] Fixes to several modules to ensure the client queries by the index for data instead of name.  
- [x] Add `utils.get_file_size` to report the file size for the dumped `.callflow` files.  
- [x] Improve logging to the users to report when files have been already processed.  